### PR TITLE
Make blake3 use InlineArray and simplify a lot of code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ libs/*.dylib
 *.dylib
 build/
 .pixi/
+kgen.trace.*

--- a/src/thistle/blake3.mojo
+++ b/src/thistle/blake3.mojo
@@ -60,6 +60,8 @@ T-Statistic:          -0.42135190883592855
 from algorithm import parallelize
 from memory import UnsafePointer, alloc, bitcast, stack_allocation
 from bit import count_trailing_zeros
+from std.utils import IndexList
+from thistle.utils import StackInlineArray
 
 comptime IV = SIMD[DType.uint32, 8](
     0x6A09E667,
@@ -83,6 +85,23 @@ comptime ROOT = UInt8(1 << 3)
 """Flag indicating the root node of the hash tree."""
 comptime CHUNK_LEN = 1024
 """The length of a BLAKE3 chunk in bytes."""
+
+
+# fmt: off
+comptime _round_idxes_arr = [
+    [(0, 1), (2, 3), (4, 5), (6, 7), (8, 9), (10, 11), (12, 13), (14, 15)],
+    [(2, 6), (3, 10), (7, 0), (4, 13), (1, 11), (12, 5), (9, 14), (15, 8)],
+    [(3, 4), (10, 12), (13, 2), (7, 14), (6, 5), (9, 0), (11, 15), (8, 1)],
+    [(10, 7), (12, 9), (14, 3), (13, 15), (4, 0), (11, 2), (5, 8), (1, 6)],
+    [(12, 13), (9, 11), (15, 10), (14, 8), (7, 2), (5, 3), (0, 1), (6, 4)],
+    [(9, 14), (11, 5), (8, 12), (15, 1), (13, 3), (0, 10), (2, 6), (4, 7)],
+    [(11, 15), (5, 0), (1, 9), (8, 6), (14, 10), (2, 12), (3, 4), (7, 13)],
+]
+comptime _v_idxes_arr = [
+    (0, 4, 8, 12), (1, 5, 9, 13), (2, 6, 10, 14), (3, 7, 11, 15),
+    (0, 5, 10, 15), (1, 6, 11, 12), (2, 7, 8, 13), (3, 4, 9, 14)
+]
+# fmt: on
 
 
 @always_inline
@@ -167,22 +186,7 @@ fn compress_internal[
     w: Int
 ](
     cv: SIMD[DType.uint32, 8],
-    mut m0: SIMD[DType.uint32, w],
-    mut m1: SIMD[DType.uint32, w],
-    mut m2: SIMD[DType.uint32, w],
-    mut m3: SIMD[DType.uint32, w],
-    mut m4: SIMD[DType.uint32, w],
-    mut m5: SIMD[DType.uint32, w],
-    mut m6: SIMD[DType.uint32, w],
-    mut m7: SIMD[DType.uint32, w],
-    mut m8: SIMD[DType.uint32, w],
-    mut m9: SIMD[DType.uint32, w],
-    mut m10: SIMD[DType.uint32, w],
-    mut m11: SIMD[DType.uint32, w],
-    mut m12: SIMD[DType.uint32, w],
-    mut m13: SIMD[DType.uint32, w],
-    mut m14: SIMD[DType.uint32, w],
-    mut m15: SIMD[DType.uint32, w],
+    var m: StackInlineArray[SIMD[DType.uint32, w], 16],
     counter: UInt64,
     blen: UInt8,
     flags: UInt8,
@@ -195,439 +199,53 @@ fn compress_internal[
 
     Args:
         cv: The chaining value.
-        m0: Message word 0.
-        m1: Message word 1.
-        m2: Message word 2.
-        m3: Message word 3.
-        m4: Message word 4.
-        m5: Message word 5.
-        m6: Message word 6.
-        m7: Message word 7.
-        m8: Message word 8.
-        m9: Message word 9.
-        m10: Message word 10.
-        m11: Message word 11.
-        m12: Message word 12.
-        m13: Message word 13.
-        m14: Message word 14.
-        m15: Message word 15.
+        m: Message words.
         counter: The chunk counter.
         blen: The block length.
         flags: The flag byte.
         out_ptr: The output pointer to store the resulting 16 SIMD vectors.
     """
-    var v0 = SIMD[DType.uint32, w](cv[0])
-    var v1 = SIMD[DType.uint32, w](cv[1])
-    var v2 = SIMD[DType.uint32, w](cv[2])
-    var v3 = SIMD[DType.uint32, w](cv[3])
-    var v4 = SIMD[DType.uint32, w](cv[4])
-    var v5 = SIMD[DType.uint32, w](cv[5])
-    var v6 = SIMD[DType.uint32, w](cv[6])
-    var v7 = SIMD[DType.uint32, w](cv[7])
-    var v8 = SIMD[DType.uint32, w](IV[0])
-    var v9 = SIMD[DType.uint32, w](IV[1])
-    var v10 = SIMD[DType.uint32, w](IV[2])
-    var v11 = SIMD[DType.uint32, w](IV[3])
-    var v12 = SIMD[DType.uint32, w](UInt32(counter & 0xFFFFFFFF))
-    var v13 = SIMD[DType.uint32, w](UInt32(counter >> 32))
-    var v14 = SIMD[DType.uint32, w](UInt32(blen))
-    var v15 = SIMD[DType.uint32, w](UInt32(flags))
+    # fmt: off
+    var v: StackInlineArray[SIMD[DType.uint32, w], 16] = [
+        {cv[0]}, {cv[1]}, {cv[2]}, {cv[3]}, {cv[4]}, {cv[5]}, {cv[6]}, {cv[7]},
+        {IV[0]}, {IV[1]}, {IV[2]}, {IV[3]},
+        {UInt32(counter & 0xFFFFFFFF)},
+        {UInt32(counter >> 32)},
+        {UInt32(blen)},
+        {UInt32(flags)},
+    ]
+    # fmt: on
 
+    @parameter
     @always_inline
-    fn round(
-        mut v0: SIMD[DType.uint32, w],
-        mut v1: SIMD[DType.uint32, w],
-        mut v2: SIMD[DType.uint32, w],
-        mut v3: SIMD[DType.uint32, w],
-        mut v4: SIMD[DType.uint32, w],
-        mut v5: SIMD[DType.uint32, w],
-        mut v6: SIMD[DType.uint32, w],
-        mut v7: SIMD[DType.uint32, w],
-        mut v8: SIMD[DType.uint32, w],
-        mut v9: SIMD[DType.uint32, w],
-        mut v10: SIMD[DType.uint32, w],
-        mut v11: SIMD[DType.uint32, w],
-        mut v12: SIMD[DType.uint32, w],
-        mut v13: SIMD[DType.uint32, w],
-        mut v14: SIMD[DType.uint32, w],
-        mut v15: SIMD[DType.uint32, w],
-        m0: SIMD[DType.uint32, w],
-        m1: SIMD[DType.uint32, w],
-        m2: SIMD[DType.uint32, w],
-        m3: SIMD[DType.uint32, w],
-        m4: SIMD[DType.uint32, w],
-        m5: SIMD[DType.uint32, w],
-        m6: SIMD[DType.uint32, w],
-        m7: SIMD[DType.uint32, w],
-        m8: SIMD[DType.uint32, w],
-        m9: SIMD[DType.uint32, w],
-        m10: SIMD[DType.uint32, w],
-        m11: SIMD[DType.uint32, w],
-        m12: SIMD[DType.uint32, w],
-        m13: SIMD[DType.uint32, w],
-        m14: SIMD[DType.uint32, w],
-        m15: SIMD[DType.uint32, w],
-    ):
-        g_v(v0, v4, v8, v12, m0, m1)
-        g_v(v1, v5, v9, v13, m2, m3)
-        g_v(v2, v6, v10, v14, m4, m5)
-        g_v(v3, v7, v11, v15, m6, m7)
-        g_v(v0, v5, v10, v15, m8, m9)
-        g_v(v1, v6, v11, v12, m10, m11)
-        g_v(v2, v7, v8, v13, m12, m13)
-        g_v(v3, v4, v9, v14, m14, m15)
+    fn round():
+        g_v(v[0], v[4], v[8], v[12], m[0], m[1])
+        g_v(v[1], v[5], v[9], v[13], m[2], m[3])
+        g_v(v[2], v[6], v[10], v[14], m[4], m[5])
+        g_v(v[3], v[7], v[11], v[15], m[6], m[7])
+        g_v(v[0], v[5], v[10], v[15], m[8], m[9])
+        g_v(v[1], v[6], v[11], v[12], m[10], m[11])
+        g_v(v[2], v[7], v[8], v[13], m[12], m[13])
+        g_v(v[3], v[4], v[9], v[14], m[14], m[15])
+    
+    @parameter
+    @always_inline
+    fn transform():
+        # fmt: off
+        m = [
+            m[2], m[6], m[3], m[10], m[7], m[0], m[4], m[13],
+            m[1], m[11], m[12], m[5], m[9], m[14], m[15], m[8],        
+        ]
+        # fmt: on
 
-    round(
-        v0,
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        m0,
-        m1,
-        m2,
-        m3,
-        m4,
-        m5,
-        m6,
-        m7,
-        m8,
-        m9,
-        m10,
-        m11,
-        m12,
-        m13,
-        m14,
-        m15,
-    )
-    var t0 = m2
-    var t1 = m6
-    var t2 = m3
-    var t3 = m10
-    var t4 = m7
-    var t5 = m0
-    var t6 = m4
-    var t7 = m13
-    var t8 = m1
-    var t9 = m11
-    var t10 = m12
-    var t11 = m5
-    var t12 = m9
-    var t13 = m14
-    var t14 = m15
-    var t15 = m8
-    round(
-        v0,
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        t0,
-        t1,
-        t2,
-        t3,
-        t4,
-        t5,
-        t6,
-        t7,
-        t8,
-        t9,
-        t10,
-        t11,
-        t12,
-        t13,
-        t14,
-        t15,
-    )
-    var u0 = t2
-    var u1 = t6
-    var u2 = t3
-    var u3 = t10
-    var u4 = t7
-    var u5 = t0
-    var u6 = t4
-    var u7 = t13
-    var u8 = t1
-    var u9 = t11
-    var u10 = t12
-    var u11 = t5
-    var u12 = t9
-    var u13 = t14
-    var u14 = t15
-    var u15 = t8
-    round(
-        v0,
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        u0,
-        u1,
-        u2,
-        u3,
-        u4,
-        u5,
-        u6,
-        u7,
-        u8,
-        u9,
-        u10,
-        u11,
-        u12,
-        u13,
-        u14,
-        u15,
-    )
-    var w0 = u2
-    var w1 = u6
-    var w2 = u3
-    var w3 = u10
-    var w4 = u7
-    var w5 = u0
-    var w6 = u4
-    var w7 = u13
-    var w8 = u1
-    var w9 = u11
-    var w10 = u12
-    var w11 = u5
-    var w12 = u9
-    var w13 = u14
-    var w14 = u15
-    var w15 = u8
-    round(
-        v0,
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        w0,
-        w1,
-        w2,
-        w3,
-        w4,
-        w5,
-        w6,
-        w7,
-        w8,
-        w9,
-        w10,
-        w11,
-        w12,
-        w13,
-        w14,
-        w15,
-    )
-    var x0 = w2
-    var x1 = w6
-    var x2 = w3
-    var x3 = w10
-    var x4 = w7
-    var x5 = w0
-    var x6 = w4
-    var x7 = w13
-    var x8 = w1
-    var x9 = w11
-    var x10 = w12
-    var x11 = w5
-    var x12 = w9
-    var x13 = w14
-    var x14 = w15
-    var x15 = w8
-    round(
-        v0,
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        x0,
-        x1,
-        x2,
-        x3,
-        x4,
-        x5,
-        x6,
-        x7,
-        x8,
-        x9,
-        x10,
-        x11,
-        x12,
-        x13,
-        x14,
-        x15,
-    )
-    var y0 = x2
-    var y1 = x6
-    var y2 = x3
-    var y3 = x10
-    var y4 = x7
-    var y5 = x0
-    var y6 = x4
-    var y7 = x13
-    var y8 = x1
-    var y9 = x11
-    var y10 = x12
-    var y11 = x5
-    var y12 = x9
-    var y13 = x14
-    var y14 = x15
-    var y15 = x8
-    round(
-        v0,
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        y0,
-        y1,
-        y2,
-        y3,
-        y4,
-        y5,
-        y6,
-        y7,
-        y8,
-        y9,
-        y10,
-        y11,
-        y12,
-        y13,
-        y14,
-        y15,
-    )
-    var z0 = y2
-    var z1 = y6
-    var z2 = y3
-    var z3 = y10
-    var z4 = y7
-    var z5 = y0
-    var z6 = y4
-    var z7 = y13
-    var z8 = y1
-    var z9 = y11
-    var z10 = y12
-    var z11 = y5
-    var z12 = y9
-    var z13 = y14
-    var z14 = y15
-    var z15 = y8
-    round(
-        v0,
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        z0,
-        z1,
-        z2,
-        z3,
-        z4,
-        z5,
-        z6,
-        z7,
-        z8,
-        z9,
-        z10,
-        z11,
-        z12,
-        z13,
-        z14,
-        z15,
-    )
+    @parameter
+    for _ in range(7):
+        round()
+        transform()
 
-    out_ptr[0] = v0
-    out_ptr[1] = v1
-    out_ptr[2] = v2
-    out_ptr[3] = v3
-    out_ptr[4] = v4
-    out_ptr[5] = v5
-    out_ptr[6] = v6
-    out_ptr[7] = v7
-    out_ptr[8] = v8
-    out_ptr[9] = v9
-    out_ptr[10] = v10
-    out_ptr[11] = v11
-    out_ptr[12] = v12
-    out_ptr[13] = v13
-    out_ptr[14] = v14
-    out_ptr[15] = v15
+    out_ptr.bitcast[UInt32]().store(
+        v.unsafe_ptr().bitcast[UInt32]().load[width=w * 16]()
+    )
 
 
 @always_inline
@@ -695,48 +313,20 @@ fn compress_core(
     Returns:
         The resulting 16 words (32 bytes of CV and 32 bytes of output).
     """
-    var m0 = block[0]
-    var m1 = block[1]
-    var m2 = block[2]
-    var m3 = block[3]
-    var m4 = block[4]
-    var m5 = block[5]
-    var m6 = block[6]
-    var m7 = block[7]
-    var m8 = block[8]
-    var m9 = block[9]
-    var m10 = block[10]
-    var m11 = block[11]
-    var m12 = block[12]
-    var m13 = block[13]
-    var m14 = block[14]
-    var m15 = block[15]
+    # fmt: off
+    var m: StackInlineArray[UInt32, 16] = [
+        block[0], block[1], block[2], block[3],
+        block[4], block[5], block[6], block[7],
+        block[8], block[9], block[10], block[11],
+        block[12], block[13], block[14], block[15],
+    ]
+    # fmt: on
 
-    var res = stack_allocation[16, SIMD[DType.uint32, 1]]()
-    compress_internal[1](
-        cv,
-        m0,
-        m1,
-        m2,
-        m3,
-        m4,
-        m5,
-        m6,
-        m7,
-        m8,
-        m9,
-        m10,
-        m11,
-        m12,
-        m13,
-        m14,
-        m15,
-        counter,
-        blen,
-        flags,
-        res,
-    )
+    var res = StackInlineArray[SIMD[DType.uint32, 1], 16](uninitialized=True)
+    compress_internal[1](cv, m^, counter, blen, flags, res.unsafe_ptr())
     var final = SIMD[DType.uint32, 16]()
+
+    @parameter
     for i in range(8):
         final[i] = res[i][0] ^ res[i + 8][0]
         final[i + 8] = res[i + 8][0] ^ cv[i]
@@ -745,477 +335,74 @@ fn compress_core(
 
 @always_inline
 fn compress_internal_16way(
-    c0: SIMD[DType.uint32, 16],
-    c1: SIMD[DType.uint32, 16],
-    c2: SIMD[DType.uint32, 16],
-    c3: SIMD[DType.uint32, 16],
-    c4: SIMD[DType.uint32, 16],
-    c5: SIMD[DType.uint32, 16],
-    c6: SIMD[DType.uint32, 16],
-    c7: SIMD[DType.uint32, 16],
-    mut m0: SIMD[DType.uint32, 16],
-    mut m1: SIMD[DType.uint32, 16],
-    mut m2: SIMD[DType.uint32, 16],
-    mut m3: SIMD[DType.uint32, 16],
-    mut m4: SIMD[DType.uint32, 16],
-    mut m5: SIMD[DType.uint32, 16],
-    mut m6: SIMD[DType.uint32, 16],
-    mut m7: SIMD[DType.uint32, 16],
-    mut m8: SIMD[DType.uint32, 16],
-    mut m9: SIMD[DType.uint32, 16],
-    mut m10: SIMD[DType.uint32, 16],
-    mut m11: SIMD[DType.uint32, 16],
-    mut m12: SIMD[DType.uint32, 16],
-    mut m13: SIMD[DType.uint32, 16],
-    mut m14: SIMD[DType.uint32, 16],
-    mut m15: SIMD[DType.uint32, 16],
+    c: StackInlineArray[SIMD[DType.uint32, 16], 8],
+    var m: StackInlineArray[SIMD[DType.uint32, 16], 16],
     base_counter: UInt64,
     blen: UInt8,
     flags: UInt8,
-    out_ptr: UnsafePointer[SIMD[DType.uint32, 16], MutAnyOrigin],
+    out_ptr: UnsafePointer[mut=True, SIMD[DType.uint32, 16]],
 ):
     """16-way SIMD internal compression.
 
     Args:
-        c0: State vector 0.
-        c1: State vector 1.
-        c2: State vector 2.
-        c3: State vector 3.
-        c4: State vector 4.
-        c5: State vector 5.
-        c6: State vector 6.
-        c7: State vector 7.
-        m0: Message vector 0.
-        m1: Message vector 1.
-        m2: Message vector 2.
-        m3: Message vector 3.
-        m4: Message vector 4.
-        m5: Message vector 5.
-        m6: Message vector 6.
-        m7: Message vector 7.
-        m8: Message vector 8.
-        m9: Message vector 9.
-        m10: Message vector 10.
-        m11: Message vector 11.
-        m12: Message vector 12.
-        m13: Message vector 13.
-        m14: Message vector 14.
-        m15: Message vector 15.
+        c: State vectors.
+        m: Message vectors.
         base_counter: Starting counter for the 16-way batch.
         blen: Block length.
         flags: Flag byte.
         out_ptr: The output pointer to store the resulting 8 vectors of 16-way SIMD words.
     """
-    var v0 = c0
-    var v1 = c1
-    var v2 = c2
-    var v3 = c3
-    var v4 = c4
-    var v5 = c5
-    var v6 = c6
-    var v7 = c7
-    var v8 = SIMD[DType.uint32, 16](IV[0])
-    var v9 = SIMD[DType.uint32, 16](IV[1])
-    var v10 = SIMD[DType.uint32, 16](IV[2])
-    var v11 = SIMD[DType.uint32, 16](IV[3])
-
     # Per-lane sequential counters
     var counters_low = SIMD[DType.uint32, 16](
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
     )
     counters_low += UInt32(base_counter & 0xFFFFFFFF)
-    var v12 = counters_low
-    var v13 = SIMD[DType.uint32, 16](UInt32(base_counter >> 32))
-    var v14 = SIMD[DType.uint32, 16](UInt32(blen))
-    var v15 = SIMD[DType.uint32, 16](UInt32(flags))
+    # fmt: off
+    var v: StackInlineArray[SIMD[DType.uint32, 16], 16] = [
+        {c[0]}, {c[1]}, {c[2]}, {c[3]}, {c[4]}, {c[5]}, {c[6]}, {c[7]},
+        {IV[0]}, {IV[1]}, {IV[2]}, {IV[3]},
+        counters_low,
+        {UInt32(base_counter >> 32)},
+        {UInt32(blen)},
+        {UInt32(flags)},
+    ]
+    # fmt: on
 
+    @parameter
     @always_inline
-    fn round(
-        mut v0: SIMD[DType.uint32, 16],
-        mut v1: SIMD[DType.uint32, 16],
-        mut v2: SIMD[DType.uint32, 16],
-        mut v3: SIMD[DType.uint32, 16],
-        mut v4: SIMD[DType.uint32, 16],
-        mut v5: SIMD[DType.uint32, 16],
-        mut v6: SIMD[DType.uint32, 16],
-        mut v7: SIMD[DType.uint32, 16],
-        mut v8: SIMD[DType.uint32, 16],
-        mut v9: SIMD[DType.uint32, 16],
-        mut v10: SIMD[DType.uint32, 16],
-        mut v11: SIMD[DType.uint32, 16],
-        mut v12: SIMD[DType.uint32, 16],
-        mut v13: SIMD[DType.uint32, 16],
-        mut v14: SIMD[DType.uint32, 16],
-        mut v15: SIMD[DType.uint32, 16],
-        m0: SIMD[DType.uint32, 16],
-        m1: SIMD[DType.uint32, 16],
-        m2: SIMD[DType.uint32, 16],
-        m3: SIMD[DType.uint32, 16],
-        m4: SIMD[DType.uint32, 16],
-        m5: SIMD[DType.uint32, 16],
-        m6: SIMD[DType.uint32, 16],
-        m7: SIMD[DType.uint32, 16],
-        m8: SIMD[DType.uint32, 16],
-        m9: SIMD[DType.uint32, 16],
-        m10: SIMD[DType.uint32, 16],
-        m11: SIMD[DType.uint32, 16],
-        m12: SIMD[DType.uint32, 16],
-        m13: SIMD[DType.uint32, 16],
-        m14: SIMD[DType.uint32, 16],
-        m15: SIMD[DType.uint32, 16],
-    ):
-        g_v[16](v0, v4, v8, v12, m0, m1)
-        g_v[16](v1, v5, v9, v13, m2, m3)
-        g_v[16](v2, v6, v10, v14, m4, m5)
-        g_v[16](v3, v7, v11, v15, m6, m7)
-        g_v[16](v0, v5, v10, v15, m8, m9)
-        g_v[16](v1, v6, v11, v12, m10, m11)
-        g_v[16](v2, v7, v8, v13, m12, m13)
-        g_v[16](v3, v4, v9, v14, m14, m15)
+    fn round():
+        g_v[16](v[0], v[4], v[8], v[12], m[0], m[1])
+        g_v[16](v[1], v[5], v[9], v[13], m[2], m[3])
+        g_v[16](v[2], v[6], v[10], v[14], m[4], m[5])
+        g_v[16](v[3], v[7], v[11], v[15], m[6], m[7])
+        g_v[16](v[0], v[5], v[10], v[15], m[8], m[9])
+        g_v[16](v[1], v[6], v[11], v[12], m[10], m[11])
+        g_v[16](v[2], v[7], v[8], v[13], m[12], m[13])
+        g_v[16](v[3], v[4], v[9], v[14], m[14], m[15])
 
-    round(
-        v0,
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        m0,
-        m1,
-        m2,
-        m3,
-        m4,
-        m5,
-        m6,
-        m7,
-        m8,
-        m9,
-        m10,
-        m11,
-        m12,
-        m13,
-        m14,
-        m15,
-    )
-    var t0 = m2
-    var t1 = m6
-    var t2 = m3
-    var t3 = m10
-    var t4 = m7
-    var t5 = m0
-    var t6 = m4
-    var t7 = m13
-    var t8 = m1
-    var t9 = m11
-    var t10 = m12
-    var t11 = m5
-    var t12 = m9
-    var t13 = m14
-    var t14 = m15
-    var t15 = m8
-    round(
-        v0,
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        t0,
-        t1,
-        t2,
-        t3,
-        t4,
-        t5,
-        t6,
-        t7,
-        t8,
-        t9,
-        t10,
-        t11,
-        t12,
-        t13,
-        t14,
-        t15,
-    )
-    var u0 = t2
-    var u1 = t6
-    var u2 = t3
-    var u3 = t10
-    var u4 = t7
-    var u5 = t0
-    var u6 = t4
-    var u7 = t13
-    var u8 = t1
-    var u9 = t11
-    var u10 = t12
-    var u11 = t5
-    var u12 = t9
-    var u13 = t14
-    var u14 = t15
-    var u15 = t8
-    round(
-        v0,
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        u0,
-        u1,
-        u2,
-        u3,
-        u4,
-        u5,
-        u6,
-        u7,
-        u8,
-        u9,
-        u10,
-        u11,
-        u12,
-        u13,
-        u14,
-        u15,
-    )
-    var w0 = u2
-    var w1 = u6
-    var w2 = u3
-    var w3 = u10
-    var w4 = u7
-    var w5 = u0
-    var w6 = u4
-    var w7 = u13
-    var w8 = u1
-    var w9 = u11
-    var w10 = u12
-    var w11 = u5
-    var w12 = u9
-    var w13 = u14
-    var w14 = u15
-    var w15 = u8
-    round(
-        v0,
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        w0,
-        w1,
-        w2,
-        w3,
-        w4,
-        w5,
-        w6,
-        w7,
-        w8,
-        w9,
-        w10,
-        w11,
-        w12,
-        w13,
-        w14,
-        w15,
-    )
-    var x0 = w2
-    var x1 = w6
-    var x2 = w3
-    var x3 = w10
-    var x4 = w7
-    var x5 = w0
-    var x6 = w4
-    var x7 = w13
-    var x8 = w1
-    var x9 = w11
-    var x10 = w12
-    var x11 = w5
-    var x12 = w9
-    var x13 = w14
-    var x14 = w15
-    var x15 = w8
-    round(
-        v0,
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        x0,
-        x1,
-        x2,
-        x3,
-        x4,
-        x5,
-        x6,
-        x7,
-        x8,
-        x9,
-        x10,
-        x11,
-        x12,
-        x13,
-        x14,
-        x15,
-    )
-    var y0 = x2
-    var y1 = x6
-    var y2 = x3
-    var y3 = x10
-    var y4 = x7
-    var y5 = x0
-    var y6 = x4
-    var y7 = x13
-    var y8 = x1
-    var y9 = x11
-    var y10 = x12
-    var y11 = x5
-    var y12 = x9
-    var y13 = x14
-    var y14 = x15
-    var y15 = x8
-    round(
-        v0,
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        y0,
-        y1,
-        y2,
-        y3,
-        y4,
-        y5,
-        y6,
-        y7,
-        y8,
-        y9,
-        y10,
-        y11,
-        y12,
-        y13,
-        y14,
-        y15,
-    )
-    var z0 = y2
-    var z1 = y6
-    var z2 = y3
-    var z3 = y10
-    var z4 = y7
-    var z5 = y0
-    var z6 = y4
-    var z7 = y13
-    var z8 = y1
-    var z9 = y11
-    var z10 = y12
-    var z11 = y5
-    var z12 = y9
-    var z13 = y14
-    var z14 = y15
-    var z15 = y8
-    round(
-        v0,
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        z0,
-        z1,
-        z2,
-        z3,
-        z4,
-        z5,
-        z6,
-        z7,
-        z8,
-        z9,
-        z10,
-        z11,
-        z12,
-        z13,
-        z14,
-        z15,
-    )
+    @parameter
+    @always_inline
+    fn transform():
+        # fmt: off
+        m = [
+            m[2], m[6], m[3], m[10], m[7], m[0], m[4], m[13],
+            m[1], m[11], m[12], m[5], m[9], m[14], m[15], m[8],        
+        ]
+        # fmt: on
 
-    out_ptr[0] = v0 ^ v8
-    out_ptr[1] = v1 ^ v9
-    out_ptr[2] = v2 ^ v10
-    out_ptr[3] = v3 ^ v11
-    out_ptr[4] = v4 ^ v12
-    out_ptr[5] = v5 ^ v13
-    out_ptr[6] = v6 ^ v14
-    out_ptr[7] = v7 ^ v15
+    @parameter
+    for _ in range(7):
+        round()
+        transform()
+
+    out_ptr[0] = v[0] ^ v[8]
+    out_ptr[1] = v[1] ^ v[9]
+    out_ptr[2] = v[2] ^ v[10]
+    out_ptr[3] = v[3] ^ v[11]
+    out_ptr[4] = v[4] ^ v[12]
+    out_ptr[5] = v[5] ^ v[13]
+    out_ptr[6] = v[6] ^ v[14]
+    out_ptr[7] = v[7] ^ v[15]
 
 
 @always_inline
@@ -1237,103 +424,39 @@ fn compress_parallel_8(
         flags: The flags.
         out_ptr: The output pointer to store the resulting 8 CVs.
     """
-    var v0 = SIMD[DType.uint32, 8](cv[0])
-    var v1 = SIMD[DType.uint32, 8](cv[1])
-    var v2 = SIMD[DType.uint32, 8](cv[2])
-    var v3 = SIMD[DType.uint32, 8](cv[3])
-    var v4 = SIMD[DType.uint32, 8](cv[4])
-    var v5 = SIMD[DType.uint32, 8](cv[5])
-    var v6 = SIMD[DType.uint32, 8](cv[6])
-    var v7 = SIMD[DType.uint32, 8](cv[7])
-    var v8 = SIMD[DType.uint32, 8](IV[0])
-    var v9 = SIMD[DType.uint32, 8](IV[1])
-    var v10 = SIMD[DType.uint32, 8](IV[2])
-    var v11 = SIMD[DType.uint32, 8](IV[3])
-    var v12 = SIMD[DType.uint32, 8](UInt32(base_counter & 0xFFFFFFFF)) + SIMD[
-        DType.uint32, 8
-    ](0, 1, 2, 3, 4, 5, 6, 7)
-    var v13 = SIMD[DType.uint32, 8](UInt32(base_counter >> 32))
-    var v14 = SIMD[DType.uint32, 8](UInt32(blen))
-    var v15 = SIMD[DType.uint32, 8](UInt32(flags))
+    var counters_low = SIMD[DType.uint32, 8](0, 1, 2, 3, 4, 5, 6, 7) + (
+        UInt32(base_counter & 0xFFFFFFFF)
+    )
+    # fmt: off
+    var v: StackInlineArray[SIMD[DType.uint32, 8], 16] = [
+        {cv[0]}, {cv[1]}, {cv[2]}, {cv[3]}, {cv[4]}, {cv[5]}, {cv[6]}, {cv[7]},
+        {IV[0]}, {IV[1]}, {IV[2]}, {IV[3]},
+        counters_low,
+        {UInt32(base_counter >> 32)},
+        {UInt32(blen)},
+        {UInt32(flags)},
+    ]
+    # fmt: on
 
-    # Round 0
-    g_vertical(v0, v4, v8, v12, m[0], m[1])
-    g_vertical(v1, v5, v9, v13, m[2], m[3])
-    g_vertical(v2, v6, v10, v14, m[4], m[5])
-    g_vertical(v3, v7, v11, v15, m[6], m[7])
-    g_vertical(v0, v5, v10, v15, m[8], m[9])
-    g_vertical(v1, v6, v11, v12, m[10], m[11])
-    g_vertical(v2, v7, v8, v13, m[12], m[13])
-    g_vertical(v3, v4, v9, v14, m[14], m[15])
+    @parameter
+    for round_idxes in _round_idxes_arr:
 
-    # Round 1
-    g_vertical(v0, v4, v8, v12, m[2], m[6])
-    g_vertical(v1, v5, v9, v13, m[3], m[10])
-    g_vertical(v2, v6, v10, v14, m[7], m[0])
-    g_vertical(v3, v7, v11, v15, m[4], m[13])
-    g_vertical(v0, v5, v10, v15, m[1], m[11])
-    g_vertical(v1, v6, v11, v12, m[12], m[5])
-    g_vertical(v2, v7, v8, v13, m[9], m[14])
-    g_vertical(v3, v4, v9, v14, m[15], m[8])
+        @parameter
+        for v_idx in range(len(_v_idxes_arr)):
+            comptime v_i = _v_idxes_arr[v_idx]
+            comptime m_i = round_idxes[v_idx]
+            g_vertical(
+                v[v_i[0]], v[v_i[1]], v[v_i[2]], v[v_i[3]], m[m_i[0]], m[m_i[1]]
+            )
 
-    # Round 2
-    g_vertical(v0, v4, v8, v12, m[3], m[4])
-    g_vertical(v1, v5, v9, v13, m[10], m[12])
-    g_vertical(v2, v6, v10, v14, m[13], m[2])
-    g_vertical(v3, v7, v11, v15, m[7], m[14])
-    g_vertical(v0, v5, v10, v15, m[6], m[5])
-    g_vertical(v1, v6, v11, v12, m[9], m[0])
-    g_vertical(v2, v7, v8, v13, m[11], m[15])
-    g_vertical(v3, v4, v9, v14, m[8], m[1])
-
-    # Round 3
-    g_vertical(v0, v4, v8, v12, m[10], m[7])
-    g_vertical(v1, v5, v9, v13, m[12], m[9])
-    g_vertical(v2, v6, v10, v14, m[14], m[3])
-    g_vertical(v3, v7, v11, v15, m[13], m[15])
-    g_vertical(v0, v5, v10, v15, m[4], m[0])
-    g_vertical(v1, v6, v11, v12, m[11], m[2])
-    g_vertical(v2, v7, v8, v13, m[5], m[8])
-    g_vertical(v3, v4, v9, v14, m[1], m[6])
-
-    # Round 4
-    g_vertical(v0, v4, v8, v12, m[12], m[13])
-    g_vertical(v1, v5, v9, v13, m[9], m[11])
-    g_vertical(v2, v6, v10, v14, m[15], m[10])
-    g_vertical(v3, v7, v11, v15, m[14], m[8])
-    g_vertical(v0, v5, v10, v15, m[7], m[2])
-    g_vertical(v1, v6, v11, v12, m[5], m[3])
-    g_vertical(v2, v7, v8, v13, m[0], m[1])
-    g_vertical(v3, v4, v9, v14, m[6], m[4])
-
-    # Round 5
-    g_vertical(v0, v4, v8, v12, m[9], m[14])
-    g_vertical(v1, v5, v9, v13, m[11], m[5])
-    g_vertical(v2, v6, v10, v14, m[8], m[12])
-    g_vertical(v3, v7, v11, v15, m[15], m[1])
-    g_vertical(v0, v5, v10, v15, m[13], m[3])
-    g_vertical(v1, v6, v11, v12, m[0], m[10])
-    g_vertical(v2, v7, v8, v13, m[2], m[6])
-    g_vertical(v3, v4, v9, v14, m[4], m[7])
-
-    # Round 6
-    g_vertical(v0, v4, v8, v12, m[11], m[15])
-    g_vertical(v1, v5, v9, v13, m[5], m[0])
-    g_vertical(v2, v6, v10, v14, m[1], m[9])
-    g_vertical(v3, v7, v11, v15, m[8], m[6])
-    g_vertical(v0, v5, v10, v15, m[9], m[10])
-    g_vertical(v1, v6, v11, v12, m[14], m[2])
-    g_vertical(v2, v7, v8, v13, m[3], m[4])
-    g_vertical(v3, v4, v9, v14, m[7], m[13])
-
-    out_ptr[0] = v0 ^ v8
-    out_ptr[1] = v1 ^ v9
-    out_ptr[2] = v2 ^ v10
-    out_ptr[3] = v3 ^ v11
-    out_ptr[4] = v4 ^ v12
-    out_ptr[5] = v5 ^ v13
-    out_ptr[6] = v6 ^ v14
-    out_ptr[7] = v7 ^ v15
+    out_ptr[0] = v[0] ^ v[8]
+    out_ptr[1] = v[1] ^ v[9]
+    out_ptr[2] = v[2] ^ v[10]
+    out_ptr[3] = v[3] ^ v[11]
+    out_ptr[4] = v[4] ^ v[12]
+    out_ptr[5] = v[5] ^ v[13]
+    out_ptr[6] = v[6] ^ v[14]
+    out_ptr[7] = v[7] ^ v[15]
 
 
 @always_inline
@@ -1357,238 +480,106 @@ fn compress_parallel_16_per_lane(
         flags: Flags.
         out_ptr: The output pointer to store the resulting 16 CVs.
     """
-    var va0 = SIMD[DType.uint32, 8]()
-    var va1 = SIMD[DType.uint32, 8]()
-    var va2 = SIMD[DType.uint32, 8]()
-    var va3 = SIMD[DType.uint32, 8]()
-    var va4 = SIMD[DType.uint32, 8]()
-    var va5 = SIMD[DType.uint32, 8]()
-    var va6 = SIMD[DType.uint32, 8]()
-    var va7 = SIMD[DType.uint32, 8]()
-    for k in range(8):
-        va0[k] = cv_lanes[k][0]
-        va1[k] = cv_lanes[k][1]
-        va2[k] = cv_lanes[k][2]
-        va3[k] = cv_lanes[k][3]
-        va4[k] = cv_lanes[k][4]
-        va5[k] = cv_lanes[k][5]
-        va6[k] = cv_lanes[k][6]
-        va7[k] = cv_lanes[k][7]
 
-    var vb0 = SIMD[DType.uint32, 8]()
-    var vb1 = SIMD[DType.uint32, 8]()
-    var vb2 = SIMD[DType.uint32, 8]()
-    var vb3 = SIMD[DType.uint32, 8]()
-    var vb4 = SIMD[DType.uint32, 8]()
-    var vb5 = SIMD[DType.uint32, 8]()
-    var vb6 = SIMD[DType.uint32, 8]()
-    var vb7 = SIMD[DType.uint32, 8]()
-    for k in range(8):
-        vb0[k] = cv_lanes[k + 8][0]
-        vb1[k] = cv_lanes[k + 8][1]
-        vb2[k] = cv_lanes[k + 8][2]
-        vb3[k] = cv_lanes[k + 8][3]
-        vb4[k] = cv_lanes[k + 8][4]
-        vb5[k] = cv_lanes[k + 8][5]
-        vb6[k] = cv_lanes[k + 8][6]
-        vb7[k] = cv_lanes[k + 8][7]
+    # fmt: off
+    comptime transpose_8x8_idxes: IndexList[64] = [
+        0, 8, 16, 24, 32, 40, 48, 56,
+        1, 9, 17, 25, 33, 41, 49, 57,
+        2, 10, 18, 26, 34, 42, 50, 58,
+        3, 11, 19, 27, 35, 43, 51, 59,
+        4, 12, 20, 28, 36, 44, 52, 60,
+        5, 13, 21, 29, 37, 45, 53, 61,
+        6, 14, 22, 30, 38, 46, 54, 62,
+        7, 15, 23, 31, 39, 47, 55, 63
+    ]
+    # fmt: on
+    var va_vec = cv_lanes.bitcast[UInt32]().load[width=64]()
+    var va_t = va_vec.shuffle[mask=transpose_8x8_idxes]()
 
-    var va8 = SIMD[DType.uint32, 8](IV[0])
-    var va9 = SIMD[DType.uint32, 8](IV[1])
-    var va10 = SIMD[DType.uint32, 8](IV[2])
-    var va11 = SIMD[DType.uint32, 8](IV[3])
-    var va12 = SIMD[DType.uint32, 8](UInt32(base_counter & 0xFFFFFFFF)) + SIMD[
-        DType.uint32, 8
-    ](0, 1, 2, 3, 4, 5, 6, 7)
-    var va13 = SIMD[DType.uint32, 8](UInt32(base_counter >> 32))
-    var va14 = SIMD[DType.uint32, 8](UInt32(blen))
-    var va15 = SIMD[DType.uint32, 8](UInt32(flags))
+    var vb_vec = (cv_lanes + 8).bitcast[UInt32]().load[width=64]()
+    var vb_t = vb_vec.shuffle[mask=transpose_8x8_idxes]()
 
-    var vb8 = SIMD[DType.uint32, 8](IV[0])
-    var vb9 = SIMD[DType.uint32, 8](IV[1])
-    var vb10 = SIMD[DType.uint32, 8](IV[2])
-    var vb11 = SIMD[DType.uint32, 8](IV[3])
-    var vb12 = SIMD[DType.uint32, 8](UInt32(base_counter & 0xFFFFFFFF)) + SIMD[
-        DType.uint32, 8
-    ](8, 9, 10, 11, 12, 13, 14, 15)
-    var vb13 = SIMD[DType.uint32, 8](UInt32(base_counter >> 32))
-    var vb14 = SIMD[DType.uint32, 8](UInt32(blen))
-    var vb15 = SIMD[DType.uint32, 8](UInt32(flags))
+    var counters_low = SIMD[DType.uint32, 8](0, 1, 2, 3, 4, 5, 6, 7) + (
+        UInt32(base_counter & 0xFFFFFFFF)
+    )
 
-    # Round 0
-    g_vertical(va0, va4, va8, va12, ma[0], ma[1])
-    g_vertical(vb0, vb4, vb8, vb12, mb[0], mb[1])
-    g_vertical(va1, va5, va9, va13, ma[2], ma[3])
-    g_vertical(vb1, vb5, vb9, vb13, mb[2], mb[3])
-    g_vertical(va2, va6, va10, va14, ma[4], ma[5])
-    g_vertical(vb2, vb6, vb10, vb14, mb[4], mb[5])
-    g_vertical(va3, va7, va11, va15, ma[6], ma[7])
-    g_vertical(vb3, vb7, vb11, vb15, mb[6], mb[7])
-    g_vertical(va0, va5, va10, va15, ma[8], ma[9])
-    g_vertical(vb0, vb5, vb10, vb15, mb[8], mb[9])
-    g_vertical(va1, va6, va11, va12, ma[10], ma[11])
-    g_vertical(vb1, vb6, vb11, vb12, mb[10], mb[11])
-    g_vertical(va2, va7, va8, va13, ma[12], ma[13])
-    g_vertical(vb2, vb7, vb8, vb13, mb[12], mb[13])
-    g_vertical(va3, va4, va9, va14, ma[14], ma[15])
-    g_vertical(vb3, vb4, vb9, vb14, mb[14], mb[15])
+    @always_inline
+    fn _from_slice(
+        vec: SIMD[DType.uint32, 64]
+    ) -> StackInlineArray[SIMD[DType.uint32, 8], 16]:
+        # fmt: off
+        return [
+            vec.slice[8, offset=0](),
+            vec.slice[8, offset=8](),
+            vec.slice[8, offset=2 * 8](),
+            vec.slice[8, offset=3 * 8](),
+            vec.slice[8, offset=4 * 8](),
+            vec.slice[8, offset=5 * 8](),
+            vec.slice[8, offset=6 * 8](),
+            vec.slice[8, offset=7 * 8](),
+            {IV[0]}, {IV[1]}, {IV[2]}, {IV[3]},
+            {counters_low},
+            {UInt32(base_counter >> 32)},
+            {UInt32(blen)},
+            {UInt32(flags)},
+        ]
+        # fmt: on
 
-    # Round 1
-    g_vertical(va0, va4, va8, va12, ma[2], ma[6])
-    g_vertical(vb0, vb4, vb8, vb12, mb[2], mb[6])
-    g_vertical(va1, va5, va9, va13, ma[3], ma[10])
-    g_vertical(vb1, vb5, vb9, vb13, mb[3], mb[10])
-    g_vertical(va2, va6, va10, va14, ma[7], ma[0])
-    g_vertical(vb2, vb6, vb10, vb14, mb[7], mb[0])
-    g_vertical(va3, va7, va11, va15, ma[4], ma[13])
-    g_vertical(vb3, vb7, vb11, vb15, mb[4], mb[13])
-    g_vertical(va0, va5, va10, va15, ma[1], ma[11])
-    g_vertical(vb0, vb5, vb10, vb15, mb[1], mb[11])
-    g_vertical(va1, va6, va11, va12, ma[12], ma[5])
-    g_vertical(vb1, vb6, vb11, vb12, mb[12], mb[5])
-    g_vertical(va2, va7, va8, va13, ma[9], ma[14])
-    g_vertical(vb2, vb7, vb8, vb13, mb[9], mb[14])
-    g_vertical(va3, va4, va9, va14, ma[15], ma[8])
-    g_vertical(vb3, vb4, vb9, vb14, mb[15], mb[8])
 
-    # Round 2
-    g_vertical(va0, va4, va8, va12, ma[3], ma[4])
-    g_vertical(vb0, vb4, vb8, vb12, mb[3], mb[4])
-    g_vertical(va1, va5, va9, va13, ma[10], ma[12])
-    g_vertical(vb1, vb5, vb9, vb13, mb[10], mb[12])
-    g_vertical(va2, va6, va10, va14, ma[13], ma[2])
-    g_vertical(vb2, vb6, vb10, vb14, mb[13], mb[2])
-    g_vertical(va3, va7, va11, va15, ma[7], ma[14])
-    g_vertical(vb3, vb7, vb11, vb15, mb[7], mb[14])
-    g_vertical(va0, va5, va10, va15, ma[6], ma[5])
-    g_vertical(vb0, vb5, vb10, vb15, mb[6], mb[5])
-    g_vertical(va1, va6, va11, va12, ma[9], ma[0])
-    g_vertical(vb1, vb6, vb11, vb12, mb[9], mb[0])
-    g_vertical(va2, va7, va8, va13, ma[11], ma[15])
-    g_vertical(vb2, vb7, vb8, vb13, mb[11], mb[15])
-    g_vertical(va3, va4, va9, va14, ma[8], ma[1])
-    g_vertical(vb3, vb4, vb9, vb14, mb[8], mb[1])
+    var va = _from_slice(va_t)
+    var vb = _from_slice(vb_t)
 
-    # Round 3
-    g_vertical(va0, va4, va8, va12, ma[10], ma[7])
-    g_vertical(vb0, vb4, vb8, vb12, mb[10], mb[7])
-    g_vertical(va1, va5, va9, va13, ma[12], ma[9])
-    g_vertical(vb1, vb5, vb9, vb13, mb[12], mb[9])
-    g_vertical(va2, va6, va10, va14, ma[14], ma[3])
-    g_vertical(vb2, vb6, vb10, vb14, mb[14], mb[3])
-    g_vertical(va3, va7, va11, va15, ma[13], ma[15])
-    g_vertical(vb3, vb7, vb11, vb15, mb[13], mb[15])
-    g_vertical(va0, va5, va10, va15, ma[4], ma[0])
-    g_vertical(vb0, vb5, vb10, vb15, mb[4], mb[0])
-    g_vertical(va1, va6, va11, va12, ma[11], ma[2])
-    g_vertical(vb1, vb6, vb11, vb12, mb[11], mb[2])
-    g_vertical(va2, va7, va8, va13, ma[5], ma[8])
-    g_vertical(vb2, vb7, vb8, vb13, mb[5], mb[8])
-    g_vertical(va3, va4, va9, va14, ma[1], ma[6])
-    g_vertical(vb3, vb4, vb9, vb14, mb[1], mb[6])
+    @parameter
+    for round_idxes in _round_idxes_arr:
 
-    # Round 4
-    g_vertical(va0, va4, va8, va12, ma[12], ma[13])
-    g_vertical(vb0, vb4, vb8, vb12, mb[12], mb[13])
-    g_vertical(va1, va5, va9, va13, ma[9], ma[11])
-    g_vertical(vb1, vb5, vb9, vb13, mb[9], mb[11])
-    g_vertical(va2, va6, va10, va14, ma[15], ma[10])
-    g_vertical(vb2, vb6, vb10, vb14, mb[15], mb[10])
-    g_vertical(va3, va7, va11, va15, ma[14], ma[8])
-    g_vertical(vb3, vb7, vb11, vb15, mb[14], mb[8])
-    g_vertical(va0, va5, va10, va15, ma[7], ma[2])
-    g_vertical(vb0, vb5, vb10, vb15, mb[7], mb[2])
-    g_vertical(va1, va6, va11, va12, ma[5], ma[3])
-    g_vertical(vb1, vb6, vb11, vb12, mb[5], mb[3])
-    g_vertical(va2, va7, va8, va13, ma[0], ma[1])
-    g_vertical(vb2, vb7, vb8, vb13, mb[0], mb[1])
-    g_vertical(va3, va4, va9, va14, ma[6], ma[4])
-    g_vertical(vb3, vb4, vb9, vb14, mb[6], mb[4])
+        @parameter
+        for v_idx in range(len(_v_idxes_arr)):
+            comptime v = _v_idxes_arr[v_idx]
+            comptime m_i = round_idxes[v_idx]
+            g_vertical(
+                va[v[0]], va[v[1]], va[v[2]], va[v[3]], ma[m_i[0]], ma[m_i[1]]
+            )
+            g_vertical(
+                vb[v[0]], vb[v[1]], vb[v[2]], vb[v[3]], mb[m_i[0]], mb[m_i[1]]
+            )
 
-    # Round 5
-    g_vertical(va0, va4, va8, va12, ma[9], ma[14])
-    g_vertical(vb0, vb4, vb8, vb12, mb[9], mb[14])
-    g_vertical(va1, va5, va9, va13, ma[11], ma[5])
-    g_vertical(vb1, vb5, vb9, vb13, mb[11], mb[5])
-    g_vertical(va2, va6, va10, va14, ma[8], ma[12])
-    g_vertical(vb2, vb6, vb10, vb14, mb[8], mb[12])
-    g_vertical(va3, va7, va11, va15, ma[15], ma[1])
-    g_vertical(vb3, vb7, vb11, vb15, mb[15], mb[1])
-    g_vertical(va0, va5, va10, va15, ma[13], ma[3])
-    g_vertical(vb0, vb5, vb10, vb15, mb[13], mb[3])
-    g_vertical(va1, va6, va11, va12, ma[0], ma[10])
-    g_vertical(vb1, vb6, vb11, vb12, mb[0], mb[10])
-    g_vertical(va2, va7, va8, va13, ma[2], ma[6])
-    g_vertical(vb2, vb7, vb8, vb13, mb[2], mb[6])
-    g_vertical(va3, va4, va9, va14, ma[4], ma[7])
-    g_vertical(vb3, vb4, vb9, vb14, mb[4], mb[7])
+    var res_a: StackInlineArray[SIMD[DType.uint32, 8], 8] = [
+        va[0] ^ va[8],
+        va[1] ^ va[9],
+        va[2] ^ va[10],
+        va[3] ^ va[11],
+        va[4] ^ va[12],
+        va[5] ^ va[13],
+        va[6] ^ va[14],
+        va[7] ^ va[15],
+    ]
+    var res_b: StackInlineArray[SIMD[DType.uint32, 8], 8] = [
+        vb[0] ^ vb[8],
+        vb[1] ^ vb[9],
+        vb[2] ^ vb[10],
+        vb[3] ^ vb[11],
+        vb[4] ^ vb[12],
+        vb[5] ^ vb[13],
+        vb[6] ^ vb[14],
+        vb[7] ^ vb[15],
+    ]
+    var res_a_t = (
+        res_a.unsafe_ptr().bitcast[UInt32]().load[width=64]()
+    ).shuffle[mask=transpose_8x8_idxes]()
+    var res_b_t = (
+        res_b.unsafe_ptr().bitcast[UInt32]().load[width=64]()
+    ).shuffle[mask=transpose_8x8_idxes]()
 
-    # Round 6
-    g_vertical(va0, va4, va8, va12, ma[11], ma[15])
-    g_vertical(vb0, vb4, vb8, vb12, mb[11], mb[15])
-    g_vertical(va1, va5, va9, va13, ma[5], ma[0])
-    g_vertical(vb1, vb5, vb9, vb13, mb[5], mb[0])
-    g_vertical(va2, va6, va10, va14, ma[1], ma[9])
-    g_vertical(vb2, vb6, vb10, vb14, mb[1], mb[9])
-    g_vertical(va3, va7, va11, va15, ma[8], ma[6])
-    g_vertical(vb3, vb7, vb11, vb15, mb[8], mb[6])
-    g_vertical(va0, va5, va10, va15, ma[9], ma[10])
-    g_vertical(vb0, vb5, vb10, vb15, mb[9], mb[10])
-    g_vertical(va1, va6, va11, va12, ma[14], ma[2])
-    g_vertical(vb1, vb6, vb11, vb12, mb[14], mb[2])
-    g_vertical(va2, va7, va8, va13, ma[3], ma[4])
-    g_vertical(vb2, vb7, vb8, vb13, mb[3], mb[4])
-    g_vertical(va3, va4, va9, va14, ma[7], ma[13])
-    g_vertical(vb3, vb4, vb9, vb14, mb[7], mb[13])
-
-    var res_a0 = va0 ^ va8
-    var res_a1 = va1 ^ va9
-    var res_a2 = va2 ^ va10
-    var res_a3 = va3 ^ va11
-    var res_a4 = va4 ^ va12
-    var res_a5 = va5 ^ va13
-    var res_a6 = va6 ^ va14
-    var res_a7 = va7 ^ va15
-
-    var res_b0 = vb0 ^ vb8
-    var res_b1 = vb1 ^ vb9
-    var res_b2 = vb2 ^ vb10
-    var res_b3 = vb3 ^ vb11
-    var res_b4 = vb4 ^ vb12
-    var res_b5 = vb5 ^ vb13
-    var res_b6 = vb6 ^ vb14
-    var res_b7 = vb7 ^ vb15
-
-    # Reverse transpose
-    for k in range(8):
-        out_ptr[k] = SIMD[DType.uint32, 8](
-            res_a0[k],
-            res_a1[k],
-            res_a2[k],
-            res_a3[k],
-            res_a4[k],
-            res_a5[k],
-            res_a6[k],
-            res_a7[k],
-        )
-        out_ptr[k + 8] = SIMD[DType.uint32, 8](
-            res_b0[k],
-            res_b1[k],
-            res_b2[k],
-            res_b3[k],
-            res_b4[k],
-            res_b5[k],
-            res_b6[k],
-            res_b7[k],
-        )
+    out_ptr.bitcast[UInt32]().store(res_a_t)
+    (out_ptr + 8).bitcast[UInt32]().store(res_b_t)
 
 
 struct Hasher:
     var key: SIMD[DType.uint32, 8]
     var original_key: SIMD[DType.uint32, 8]
-    var cv_stack: UnsafePointer[SIMD[DType.uint32, 8], MutExternalOrigin]
+    var cv_stack: StackInlineArray[SIMD[DType.uint32, 8], 54]
     var stack_len: Int
-    var buf: UnsafePointer[UInt8, MutExternalOrigin]
+    var buf: StackInlineArray[UInt8, 64]
     var buf_len: Int
     var chunk_counter: UInt64
     var blocks_compressed: Int
@@ -1596,32 +587,27 @@ struct Hasher:
     fn __init__(out self):
         self.key = IV
         self.original_key = IV
-        # Allocate space for 54 SIMD8 vectors (UInt32)
-        # Currently Mojo OwnedPointer (Heap based) or InlineArray will cause huge bounds checking.
-        # When the compiler improves we might switch to InlineArray as it's not that big of a difference in speed.
-        self.cv_stack = alloc[SIMD[DType.uint32, 8]](54)
+        self.cv_stack = {uninitialized=True}
 
         self.stack_len = 0
 
-        self.buf = alloc[UInt8](64)
+        self.buf = {uninitialized=True}
 
         self.buf_len = 0
         self.chunk_counter = 0
         self.blocks_compressed = 0
 
-    fn __deinit__(mut self):
-        self.cv_stack.free()
-        self.buf.free()
-
     fn update(mut self, input: Span[UInt8]):
         var d = input
         while len(d) > 0:
             if self.buf_len == 64:
+                # TODO: use simd_width_of[dtype]() and make the functions
+                # be more generic based on the width
                 var blk = (
                     # Note: Defaults to AVX2 (AVX-512 = Width 32)
                     # Will need to use Sys to set targets any target that dooesn't support AVX2 will spill (ARM)
                     # Sys is just a pain to use at the moment there's like hundreds of targets so it's useless to try and target all cpus.
-                    self.buf.bitcast[UInt32]().load[width=16]()
+                    self.buf.unsafe_ptr().bitcast[UInt32]().load[width=16]()
                 )
 
                 if self.blocks_compressed == 15:
@@ -1634,16 +620,7 @@ struct Hasher:
                             (CHUNK_START if self.blocks_compressed == 0 else 0)
                             | CHUNK_END,
                         )
-                        var chunk_cv = SIMD[DType.uint32, 8](
-                            res[0],
-                            res[1],
-                            res[2],
-                            res[3],
-                            res[4],
-                            res[5],
-                            res[6],
-                            res[7],
-                        )
+                        var chunk_cv = res.slice[8]()
                         self.add_chunk_cv(chunk_cv, self.chunk_counter)
                         self.key = self.original_key
                         self.chunk_counter += 1
@@ -1660,22 +637,13 @@ struct Hasher:
                         64,
                         (CHUNK_START if self.blocks_compressed == 0 else 0),
                     )
-                    self.key = SIMD[DType.uint32, 8](
-                        res[0],
-                        res[1],
-                        res[2],
-                        res[3],
-                        res[4],
-                        res[5],
-                        res[6],
-                        res[7],
-                    )
+                    self.key = res.slice[8]()
                     self.blocks_compressed += 1
                     self.buf_len = 0
 
             var take = min(len(d), 64 - self.buf_len)
             for i in range(take):
-                (self.buf + self.buf_len + i)[] = d[i]
+                self.buf.unsafe_set(self.buf_len + i, d[i])
             self.buf_len += take
             d = d[take:]
 
@@ -1689,15 +657,13 @@ struct Hasher:
         for _ in range(num_merges):
             if self.stack_len == 0:
                 break
-            var left = (self.cv_stack + (self.stack_len - 1))[]
+            var left = self.cv_stack.unsafe_get((self.stack_len - 1))
             var res = compress_core(
                 self.original_key, left.join(new_cv), 0, 64, PARENT
             )
-            new_cv = SIMD[DType.uint32, 8](
-                res[0], res[1], res[2], res[3], res[4], res[5], res[6], res[7]
-            )
+            new_cv = res.slice[8]()
             self.stack_len -= 1
-        (self.cv_stack + self.stack_len)[] = new_cv
+        self.cv_stack.unsafe_set(self.stack_len, new_cv)
         self.stack_len += 1
 
     @always_inline
@@ -1707,17 +673,15 @@ struct Hasher:
         var total_at_level = self.chunk_counter >> height
 
         while (total_at_level & 1) == 0 and self.stack_len > 0:
-            var left = (self.cv_stack + (self.stack_len - 1))[]
+            var left = self.cv_stack.unsafe_get((self.stack_len - 1))
             var res = compress_core(
                 self.original_key, left.join(new_cv), 0, 64, PARENT
             )
-            new_cv = SIMD[DType.uint32, 8](
-                res[0], res[1], res[2], res[3], res[4], res[5], res[6], res[7]
-            )
+            new_cv = res.slice[8]()
             self.stack_len -= 1
             total_at_level >>= 1
 
-        (self.cv_stack + self.stack_len)[] = new_cv
+        self.cv_stack.unsafe_set(self.stack_len, new_cv)
         self.stack_len += 1
 
     @always_inline
@@ -1730,16 +694,23 @@ struct Hasher:
             out_ptr: Pointer to write the resulting hash to.
             out_len: The number of bytes to write.
         """
-        var temp_buf = stack_allocation[64, UInt8]()
+        var temp_buf = StackInlineArray[UInt8, 64](uninitialized=True)
         # Initialize temp_buf to 0 and copy self.buf
+        # TODO: maybe if we have self.buf always have 0 where > self.buf_len
+        # we can avoid this entirely. We could also just load the whole
+        # vector and mask based on self.buf_len.
+
+        @parameter
         for i in range(64):
             if i < self.buf_len:
                 temp_buf[i] = self.buf[i]
             else:
                 temp_buf[i] = 0
+        
+        # TODO: use simd_width_of[dtype]() and make everything more generic
         # Note: Defaults to AVX2 (AVX-512 = Width 32)
         # Will need to use Sys to set targets any target that dooesn't support AVX2 will spill (ARM)
-        var blk = temp_buf.bitcast[UInt32]().load[width=16]()
+        var blk = temp_buf.unsafe_ptr().bitcast[UInt32]().load[width=16]()
 
         var flags = (
             CHUNK_START if self.blocks_compressed == 0 else UInt8(0)
@@ -1761,29 +732,18 @@ struct Hasher:
             var res = compress_core(
                 self.key, blk, self.chunk_counter, UInt8(self.buf_len), flags
             )
-            var out_cv = SIMD[DType.uint32, 8](
-                res[0], res[1], res[2], res[3], res[4], res[5], res[6], res[7]
-            )
+            var out_cv = res.slice[8]()
             var depth = self.stack_len
             while depth > 1:
                 depth -= 1
-                var left = (self.cv_stack + depth)[]
+                var left = self.cv_stack.unsafe_get(depth)
                 var p_res = compress_core(
                     self.original_key, left.join(out_cv), 0, 64, PARENT
                 )
-                out_cv = SIMD[DType.uint32, 8](
-                    p_res[0],
-                    p_res[1],
-                    p_res[2],
-                    p_res[3],
-                    p_res[4],
-                    p_res[5],
-                    p_res[6],
-                    p_res[7],
-                )
+                out_cv = p_res.slice[8]()
 
             working_key = self.original_key
-            working_blk = self.cv_stack[].join(out_cv)
+            working_blk = self.cv_stack.unsafe_get(0).join(out_cv)
             working_counter = 0
             working_blen = 64
             working_flags = PARENT | ROOT
@@ -1823,199 +783,131 @@ fn blake3_parallel_hash(input: Span[UInt8], out_len: Int = 32) -> List[UInt8]:
         fn process_batch(tid: Int):
             var task_base = tid * BSIZE
             var base_ptr = d.unsafe_ptr().bitcast[UInt32]()
-            var local_cvs = stack_allocation[64, SIMD[DType.uint32, 8]]()
-
+            var local_cvs = StackInlineArray[SIMD[DType.uint32, 8], 64](
+                uninitialized=True
+            )
+            # TODO: I think there is a lot of room for perf improvement here
+            # because these transformations are known at compile time, we should
+            # be able to vectorize this according to the device's simd_width
             for i in range(0, BSIZE, 16):
                 var base = task_base + i
-                var c0 = SIMD[DType.uint32, 16](IV[0])
-                var c1 = SIMD[DType.uint32, 16](IV[1])
-                var c2 = SIMD[DType.uint32, 16](IV[2])
-                var c3 = SIMD[DType.uint32, 16](IV[3])
-                var c4 = SIMD[DType.uint32, 16](IV[4])
-                var c5 = SIMD[DType.uint32, 16](IV[5])
-                var c6 = SIMD[DType.uint32, 16](IV[6])
-                var c7 = SIMD[DType.uint32, 16](IV[7])
+                # fmt: off
+                var c: StackInlineArray[SIMD[DType.uint32, 16], 8] = [
+                    {IV[0]}, {IV[1]}, {IV[2]}, {IV[3]},
+                    {IV[4]}, {IV[5]}, {IV[6]}, {IV[7]},
+                ]
+                # fmt: on
 
                 for b in range(16):
                     var flags = (CHUNK_START if b == 0 else UInt8(0)) | (
                         CHUNK_END if b == 15 else 0
                     )
-                    var ma = stack_allocation[16, SIMD[DType.uint32, 8]]()
-                    var mb = stack_allocation[16, SIMD[DType.uint32, 8]]()
+                    var ma = StackInlineArray[SIMD[DType.uint32, 8], 16](
+                        uninitialized=True
+                    )
+                    var mb = StackInlineArray[SIMD[DType.uint32, 8], 16](
+                        uninitialized=True
+                    )
 
                     for j in range(4):
                         var joff = j * 4
-                        var v0a = base_ptr.load[width=4](
-                            (base + 0) * 256 + b * 16 + joff
-                        ).interleave(
-                            base_ptr.load[width=4](
-                                (base + 1) * 256 + b * 16 + joff
-                            )
-                        )
-                        var v1a = base_ptr.load[width=4](
-                            (base + 2) * 256 + b * 16 + joff
-                        ).interleave(
-                            base_ptr.load[width=4](
-                                (base + 3) * 256 + b * 16 + joff
-                            )
-                        )
-                        var v2a = base_ptr.load[width=4](
-                            (base + 4) * 256 + b * 16 + joff
-                        ).interleave(
-                            base_ptr.load[width=4](
-                                (base + 5) * 256 + b * 16 + joff
-                            )
-                        )
-                        var v3a = base_ptr.load[width=4](
-                            (base + 6) * 256 + b * 16 + joff
-                        ).interleave(
-                            base_ptr.load[width=4](
-                                (base + 7) * 256 + b * 16 + joff
-                            )
-                        )
-                        var t0a = v0a.shuffle[0, 1, 8, 9, 2, 3, 10, 11](v1a)
-                        var t1a = v2a.shuffle[0, 1, 8, 9, 2, 3, 10, 11](v3a)
-                        ma[joff + 0] = t0a.shuffle[0, 1, 2, 3, 8, 9, 10, 11](
-                            t1a
-                        )
-                        ma[joff + 1] = t0a.shuffle[4, 5, 6, 7, 12, 13, 14, 15](
-                            t1a
-                        )
-                        var t2a = v0a.shuffle[4, 5, 12, 13, 6, 7, 14, 15](v1a)
-                        var t3a = v2a.shuffle[4, 5, 12, 13, 6, 7, 14, 15](v3a)
-                        ma[joff + 2] = t2a.shuffle[0, 1, 2, 3, 8, 9, 10, 11](
-                            t3a
-                        )
-                        ma[joff + 3] = t2a.shuffle[4, 5, 6, 7, 12, 13, 14, 15](
-                            t3a
-                        )
 
-                        var v0b = base_ptr.load[width=4](
-                            (base + 8) * 256 + b * 16 + joff
-                        ).interleave(
-                            base_ptr.load[width=4](
-                                (base + 9) * 256 + b * 16 + joff
+                        @parameter
+                        @always_inline
+                        fn _load_idx(v: Int) -> SIMD[DType.uint32, 4]:
+                            return base_ptr.load[width=4](
+                                (base + v) * 256 + b * 16 + joff
                             )
-                        )
-                        var v1b = base_ptr.load[width=4](
-                            (base + 10) * 256 + b * 16 + joff
-                        ).interleave(
-                            base_ptr.load[width=4](
-                                (base + 11) * 256 + b * 16 + joff
-                            )
-                        )
-                        var v2b = base_ptr.load[width=4](
-                            (base + 12) * 256 + b * 16 + joff
-                        ).interleave(
-                            base_ptr.load[width=4](
-                                (base + 13) * 256 + b * 16 + joff
-                            )
-                        )
-                        var v3b = base_ptr.load[width=4](
-                            (base + 14) * 256 + b * 16 + joff
-                        ).interleave(
-                            base_ptr.load[width=4](
-                                (base + 15) * 256 + b * 16 + joff
-                            )
-                        )
-                        var t0b = v0b.shuffle[0, 1, 8, 9, 2, 3, 10, 11](v1b)
-                        var t1b = v2b.shuffle[0, 1, 8, 9, 2, 3, 10, 11](v3b)
-                        mb[joff + 0] = t0b.shuffle[0, 1, 2, 3, 8, 9, 10, 11](
-                            t1b
-                        )
-                        mb[joff + 1] = t0b.shuffle[4, 5, 6, 7, 12, 13, 14, 15](
-                            t1b
-                        )
-                        var t2b = v0b.shuffle[4, 5, 12, 13, 6, 7, 14, 15](v1b)
-                        var t3b = v2b.shuffle[4, 5, 12, 13, 6, 7, 14, 15](v3b)
-                        mb[joff + 2] = t2b.shuffle[0, 1, 2, 3, 8, 9, 10, 11](
-                            t3b
-                        )
-                        mb[joff + 3] = t2b.shuffle[4, 5, 6, 7, 12, 13, 14, 15](
-                            t3b
-                        )
 
-                    var am0 = ma[0].join(mb[0])
-                    var am1 = ma[1].join(mb[1])
-                    var am2 = ma[2].join(mb[2])
-                    var am3 = ma[3].join(mb[3])
-                    var am4 = ma[4].join(mb[4])
-                    var am5 = ma[5].join(mb[5])
-                    var am6 = ma[6].join(mb[6])
-                    var am7 = ma[7].join(mb[7])
-                    var am8 = ma[8].join(mb[8])
-                    var am9 = ma[9].join(mb[9])
-                    var am10 = ma[10].join(mb[10])
-                    var am11 = ma[11].join(mb[11])
-                    var am12 = ma[12].join(mb[12])
-                    var am13 = ma[13].join(mb[13])
-                    var am14 = ma[14].join(mb[14])
-                    var am15 = ma[15].join(mb[15])
+                        var v0a = _load_idx(0).interleave(_load_idx(1))
+                        var v1a = _load_idx(2).interleave(_load_idx(3))
+                        var v2a = _load_idx(4).interleave(_load_idx(5))
+                        var v3a = _load_idx(6).interleave(_load_idx(7))
+                        comptime t_01_mask: IndexList[8] = [
+                            0, 1, 8, 9, 2, 3, 10, 11
+                        ]
+                        comptime t_23_mask: IndexList[8] = [
+                            4, 5, 12, 13, 6, 7, 14, 15
+                        ]
+                        comptime mask_even: IndexList[8] = [
+                            0, 1, 2, 3, 8, 9, 10, 11
+                        ]
+                        comptime mask_odd: IndexList[8] = [
+                            4, 5, 6, 7, 12, 13, 14, 15
+                        ]
+                        var t0a = v0a.shuffle[mask=t_01_mask](v1a)
+                        var t1a = v2a.shuffle[mask=t_01_mask](v3a)
+                        ma.unsafe_set(joff + 0, t0a.shuffle[mask=mask_even](t1a))
+                        ma.unsafe_set(joff + 1, t0a.shuffle[mask=mask_odd](t1a))
+                        var t2a = v0a.shuffle[mask=t_23_mask](v1a)
+                        var t3a = v2a.shuffle[mask=t_23_mask](v3a)
+                        ma.unsafe_set(joff + 2, t2a.shuffle[mask=mask_even](t3a))
+                        ma.unsafe_set(joff + 3, t2a.shuffle[mask=mask_odd](t3a))
 
-                    var res = stack_allocation[8, SIMD[DType.uint32, 16]]()
+                        var v0b = _load_idx(8).interleave(_load_idx(9))
+                        var v1b = _load_idx(10).interleave(_load_idx(11))
+                        var v2b = _load_idx(12).interleave(_load_idx(13))
+                        var v3b = _load_idx(14).interleave(_load_idx(15))
+                        var t0b = v0b.shuffle[mask=t_01_mask](v1b)
+                        var t1b = v2b.shuffle[mask=t_01_mask](v3b)
+                        mb.unsafe_set(joff + 0, t0b.shuffle[mask=mask_even](t1b))
+                        mb.unsafe_set(joff + 1, t0b.shuffle[mask=mask_odd](t1b))
+                        var t2b = v0b.shuffle[mask=t_23_mask](v1b)
+                        var t3b = v2b.shuffle[mask=t_23_mask](v3b)
+                        mb.unsafe_set(joff + 2, t2b.shuffle[mask=mask_even](t3b))
+                        mb.unsafe_set(joff + 3, t2b.shuffle[mask=mask_odd](t3b))
+
+                    var am: StackInlineArray[SIMD[DType.uint32, 16], 16] = [
+                        ma[0].join(mb[0]),
+                        ma[1].join(mb[1]),
+                        ma[2].join(mb[2]),
+                        ma[3].join(mb[3]),
+                        ma[4].join(mb[4]),
+                        ma[5].join(mb[5]),
+                        ma[6].join(mb[6]),
+                        ma[7].join(mb[7]),
+                        ma[8].join(mb[8]),
+                        ma[9].join(mb[9]),
+                        ma[10].join(mb[10]),
+                        ma[11].join(mb[11]),
+                        ma[12].join(mb[12]),
+                        ma[13].join(mb[13]),
+                        ma[14].join(mb[14]),
+                        ma[15].join(mb[15]),
+                    ]
+
+                    var res = StackInlineArray[SIMD[DType.uint32, 16], 8](
+                        uninitialized=True
+                    )
                     compress_internal_16way(
-                        c0,
-                        c1,
-                        c2,
-                        c3,
-                        c4,
-                        c5,
-                        c6,
-                        c7,
-                        am0,
-                        am1,
-                        am2,
-                        am3,
-                        am4,
-                        am5,
-                        am6,
-                        am7,
-                        am8,
-                        am9,
-                        am10,
-                        am11,
-                        am12,
-                        am13,
-                        am14,
-                        am15,
+                        c,
+                        am^,
                         UInt64(base),
                         64,
                         flags,
-                        res,
+                        res.unsafe_ptr(),
                     )
-                    c0 = res[0]
-                    c1 = res[1]
-                    c2 = res[2]
-                    c3 = res[3]
-                    c4 = res[4]
-                    c5 = res[5]
-                    c6 = res[6]
-                    c7 = res[7]
+                    c = res^
 
                 for k in range(16):
-                    local_cvs[i + k] = SIMD[DType.uint32, 8](
-                        c0[k], c1[k], c2[k], c3[k], c4[k], c5[k], c6[k], c7[k]
+                    # fmt: off
+                    var vec = SIMD[DType.uint32, 8](
+                        c[0][k], c[1][k], c[2][k], c[3][k],
+                        c[4][k], c[5][k], c[6][k], c[7][k],
                     )
+                    # fmt: on
+                    local_cvs.unsafe_set(i + k, vec)
 
             var current_len = 64
             while current_len > 1:
                 current_len >>= 1
                 for i in range(current_len):
-                    var left = local_cvs[i * 2]
-                    var right = local_cvs[i * 2 + 1]
+                    var left = local_cvs.unsafe_get(i * 2)
+                    var right = local_cvs.unsafe_get(i * 2 + 1)
                     var combined = compress_core(
                         IV, left.join(right), 0, 64, PARENT
                     )
-                    local_cvs[i] = SIMD[DType.uint32, 8](
-                        combined[0],
-                        combined[1],
-                        combined[2],
-                        combined[3],
-                        combined[4],
-                        combined[5],
-                        combined[6],
-                        combined[7],
-                    )
+                    local_cvs.unsafe_set(i, combined.slice[8]())
             batch_roots_ptr[tid] = local_cvs[0]
 
         parallelize[process_batch](num_full_batches)

--- a/src/thistle/utils.mojo
+++ b/src/thistle/utils.mojo
@@ -1,0 +1,134 @@
+from builtin.rebind import downcast
+from builtin.constrained import _constrained_conforms_to
+from memory import stack_allocation
+
+struct StackInlineArray[ElementType: Copyable, size: Int](Copyable):
+    var _ptr: UnsafePointer[Self.ElementType, MutExternalOrigin]
+
+    @always_inline
+    fn __init__(out self, *, uninitialized: Bool):
+        self._ptr = stack_allocation[Self.size, Self.ElementType]()
+
+    @always_inline
+    fn __init__(out self, var *elems: Self.ElementType, __list_literal__: ()):
+        debug_assert(
+            len(elems) == Self.size, "No. of elems must match array size"
+        )
+        self = Self(storage=elems^)
+
+    @always_inline
+    fn __init__[
+        origin: MutOrigin,
+        //,
+    ](
+        out self,
+        *,
+        var storage: VariadicListMem[
+            elt_is_mutable=True, origin=origin, Self.ElementType, is_owned=True
+        ],
+    ):
+
+        debug_assert(
+            len(storage) == Self.size,
+            "Expected variadic list of length ",
+            Self.size,
+            ", received ",
+            len(storage),
+        )
+        self = {uninitialized=True}
+
+        var ptr = self.unsafe_ptr()
+
+        # Move each element into the array storage.
+        @parameter
+        for i in range(Self.size):
+            # Safety: We own the elements in the variadic list.
+            ptr.init_pointee_move_from(
+                UnsafePointer(to=storage[i]).unsafe_mut_cast[True]()
+            )
+            ptr += 1
+
+        # Do not destroy the elements when their backing storage goes away.
+        # FIXME: Why doesn't consume_elements work here?
+        storage^._anihilate()
+
+    @always_inline
+    fn unsafe_ptr[
+        origin: Origin, address_space: AddressSpace, //
+    ](ref[origin, address_space] self) -> UnsafePointer[
+        Self.ElementType,
+        origin,
+        address_space=address_space
+    ]:
+        return (
+            self._ptr
+            .unsafe_mut_cast[origin.mut]()
+            .unsafe_origin_cast[origin]()
+            .address_space_cast[address_space]()
+        )
+
+    @always_inline
+    fn unsafe_get[I: Indexer](ref self, idx: I) -> ref[MutExternalOrigin] Self.ElementType:
+        var i = index(idx)
+        debug_assert(
+            0 <= i < Self.size,
+            " InlineArray.unsafe_get() index out of bounds: ",
+            i,
+            " should be greater than or equal to 0 and less than ",
+            Self.size,
+        )
+        return self._ptr[i]
+
+    @always_inline
+    fn __getitem__[
+        idx: Some[Indexer]
+    ](ref self) -> ref[MutExternalOrigin] Self.ElementType:
+        comptime i = index(idx)
+        constrained[0 <= i < Self.size, "Index must be within bounds."]()
+        return self.unsafe_get(i)
+
+
+    # FIXME: temporary workaround
+    @always_inline
+    fn __getitem__[
+        idx: Int
+    ](ref self) -> ref[MutExternalOrigin] Self.ElementType:
+        comptime i = index(idx)
+        constrained[0 <= i < Self.size, "Index must be within bounds."]()
+        return self.unsafe_get(i)
+
+    @always_inline
+    fn unsafe_set[
+        _T: Copyable & ImplicitlyDestructible
+    ](mut self: StackInlineArray[_T], idx: Int, var value: _T):
+        debug_assert(
+            0 <= idx < Self.size,
+            (
+                "The index provided must be within the range [0, len(List) -1]"
+                " when using List.unsafe_set()"
+            ),
+        )
+        (self._ptr + idx).destroy_pointee()
+        (self._ptr + idx).init_pointee_move(value^)
+
+    fn __del__(deinit self):
+        """Deallocates the array and destroys its elements."""
+
+        _constrained_conforms_to[
+            conforms_to(Self.ElementType, ImplicitlyDestructible),
+            Parent=Self,
+            Element = Self.ElementType,
+            ParentConformsTo="ImplicitlyDestructible",
+        ]()
+        comptime TDestructible = downcast[
+            Self.ElementType, ImplicitlyDestructible
+        ]
+
+        @parameter
+        if not TDestructible.__del__is_trivial:
+            @parameter
+            for idx in range(Self.size):
+                var ptr = self.unsafe_ptr() + idx
+                ptr.bitcast[TDestructible]().destroy_pointee()
+
+

--- a/tests/benchmark.mojo
+++ b/tests/benchmark.mojo
@@ -12,6 +12,8 @@ from thistle.sha2 import sha256_hash, sha512_hash
 from thistle.sha3 import sha3_256
 
 
+comptime _MiB = 1024 * 1024
+
 fn generate_data(length: Int) -> List[UInt8]:
     var data = List[UInt8](capacity=length)
     for i in range(length):
@@ -29,9 +31,17 @@ fn benchmark_sha256(data: List[UInt8], duration_secs: Float64) -> String:
         count += 1
     var end = perf_counter()
     var duration = end - start
-    var mb = Float64(len(data) * count) / (1024 * 1024)
+    var mb = Float64(len(data) * count) / _MiB
     var mbps = mb / duration
-    return "sha256 | throughput: " + String(mbps)[:6] + " mb/s, hashes: " + String(count) + ", time: " + String(duration)[:4] + "s"
+    return String(
+        "sha256 | throughput: ",
+        round(mbps, 6),
+        " mb/s, hashes: ",
+        count,
+        ", time: ",
+        round(duration, 4),
+        "s"
+    )
 
 
 fn benchmark_sha512(data: List[UInt8], duration_secs: Float64) -> String:
@@ -44,9 +54,17 @@ fn benchmark_sha512(data: List[UInt8], duration_secs: Float64) -> String:
         count += 1
     var end = perf_counter()
     var duration = end - start
-    var mb = Float64(len(data) * count) / (1024 * 1024)
+    var mb = Float64(len(data) * count) / _MiB
     var mbps = mb / duration
-    return "sha512 | throughput: " + String(mbps)[:6] + " mb/s, hashes: " + String(count) + ", time: " + String(duration)[:4] + "s"
+    return String(
+        "sha512 | throughput: ",
+        round(mbps, 6),
+        " mb/s, hashes: ",
+        count,
+        ", time: ",
+        round(duration, 4),
+        "s"
+    )
 
 
 fn benchmark_sha3_256(data: List[UInt8], duration_secs: Float64) -> String:
@@ -59,9 +77,17 @@ fn benchmark_sha3_256(data: List[UInt8], duration_secs: Float64) -> String:
         count += 1
     var end = perf_counter()
     var duration = end - start
-    var mb = Float64(len(data) * count) / (1024 * 1024)
+    var mb = Float64(len(data) * count) / _MiB
     var mbps = mb / duration
-    return "sha3-256 | throughput: " + String(mbps)[:6] + " mb/s, hashes: " + String(count) + ", time: " + String(duration)[:4] + "s"
+    return String(
+        "sha3-256 | throughput: ",
+        round(mbps, 6),
+        " mb/s, hashes: ",
+        count,
+        ", time: ",
+        round(duration, 4),
+        "s"
+    )
 
 
 fn benchmark_blake2b(data: List[UInt8], duration_secs: Float64) -> String:
@@ -75,9 +101,17 @@ fn benchmark_blake2b(data: List[UInt8], duration_secs: Float64) -> String:
         count += 1
     var end = perf_counter()
     var duration = end - start
-    var mb = Float64(len(data) * count) / (1024 * 1024)
+    var mb = Float64(len(data) * count) / _MiB
     var mbps = mb / duration
-    return "blake2b | throughput: " + String(mbps)[:6] + " mb/s, hashes: " + String(count) + ", time: " + String(duration)[:4] + "s"
+    return String(
+        "blake2b | throughput: ",
+        round(mbps, 6),
+        " mb/s, hashes: ",
+        count,
+        ", time: ",
+        round(duration, 4),
+        "s"
+    )
 
 
 fn benchmark_blake3(data: List[UInt8], duration_secs: Float64) -> String:
@@ -90,9 +124,17 @@ fn benchmark_blake3(data: List[UInt8], duration_secs: Float64) -> String:
         count += 1
     var end = perf_counter()
     var duration = end - start
-    var mb = Float64(len(data) * count) / (1024 * 1024)
+    var mb = Float64(len(data) * count) / _MiB
     var mbps = mb / duration
-    return "blake3 | throughput: " + String(mbps)[:6] + " mb/s, hashes: " + String(count) + ", time: " + String(duration)[:4] + "s"
+    return String(
+        "blake3 | throughput: ",
+        round(mbps, 6),
+        " mb/s, hashes: ",
+        count,
+        ", time: ",
+        round(duration, 4),
+        "s"
+    )
 
 
 fn benchmark_camellia(data_size: Int, duration_secs: Float64) -> String:
@@ -100,12 +142,12 @@ fn benchmark_camellia(data_size: Int, duration_secs: Float64) -> String:
     for i in range(16):
         key.append(UInt8(i))
     var cipher = CamelliaCipher(Span[UInt8](key))
-    
+
     var data = List[UInt8](capacity=16)
     for i in range(16):
         data.append(UInt8(i % 256))
     var data_span = Span[UInt8](data)
-    
+
     var checksum: UInt64 = 0
     var count = 0
     var start = perf_counter()
@@ -116,8 +158,16 @@ fn benchmark_camellia(data_size: Int, duration_secs: Float64) -> String:
     var end = perf_counter()
     var duration = end - start
     _ = checksum
-    var mbps = Float64(count * 16) / (1024 * 1024) / duration
-    return "camellia | throughput: " + String(mbps)[:6] + " mb/s, blocks: " + String(count) + ", time: " + String(duration)[:4] + "s"
+    var mbps = Float64(count * 16) / _MiB / duration
+    return String(
+        "camellia | throughput: ",
+        round(mbps, 6),
+        " mb/s, blocks: ",
+        count,
+        ", time: ",
+        round(duration, 4),
+        "s"
+    )
 
 
 fn benchmark_chacha20(data_size: Int, duration_secs: Float64) -> String:
@@ -125,14 +175,14 @@ fn benchmark_chacha20(data_size: Int, duration_secs: Float64) -> String:
     for i in range(32):
         key[i] = UInt8(i)
     var nonce = SIMD[DType.uint8, 12](0)
-    
+
     var data = List[UInt8](capacity=data_size)
     for i in range(data_size):
         data.append(UInt8(i % 256))
     var span = Span[mut=True, UInt8](data)
-    
+
     var cipher = ChaCha20(key, nonce)
-    
+
     var checksum: UInt64 = 0
     var count = 0
     var start = perf_counter()
@@ -143,21 +193,29 @@ fn benchmark_chacha20(data_size: Int, duration_secs: Float64) -> String:
     var end = perf_counter()
     var duration = end - start
     _ = checksum
-    var mb = Float64(data_size * count) / (1024 * 1024)
+    var mb = Float64(data_size * count) / _MiB
     var mbps = mb / duration
-    return "chacha20 | throughput: " + String(mbps)[:6] + " mb/s, encrypts: " + String(count) + ", time: " + String(duration)[:4] + "s"
+    return String(
+        "chacha20 | throughput: ",
+        round(mbps, 6),
+        " mb/s, encrypts: ",
+        count,
+        ", time: ",
+        round(duration, 4),
+        "s"
+    )
 
 
 fn benchmark_kcipher2(data_size: Int, duration_secs: Float64) -> String:
     var key = SIMD[DType.uint32, 4](0, 0, 0, 0)
     var iv = SIMD[DType.uint32, 4](0, 0, 0, 0)
     var cipher = KCipher2(key, iv)
-    
+
     var data = List[UInt8](capacity=data_size)
     for i in range(data_size):
         data.append(UInt8(i % 256))
     var span = Span[mut=True, UInt8](data)
-    
+
     var count = 0
     var start = perf_counter()
     while perf_counter() - start < duration_secs:
@@ -166,18 +224,26 @@ fn benchmark_kcipher2(data_size: Int, duration_secs: Float64) -> String:
         count += 1
     var end = perf_counter()
     var duration = end - start
-    var mb = Float64(data_size * count) / (1024 * 1024)
+    var mb = Float64(data_size * count) / _MiB
     var mbps = mb / duration
-    return "kcipher2 | throughput: " + String(mbps)[:6] + " mb/s, encrypts: " + String(count) + ", time: " + String(duration)[:4] + "s"
+    return String(
+        "kcipher2 | throughput: ",
+        round(mbps, 6),
+        " mb/s, encrypts: ",
+        count,
+        ", time: ",
+        round(duration, 4),
+        "s"
+    )
 
 
 fn benchmark_argon2(duration_secs: Float64) -> String:
     var password = String("password").as_bytes()
     var salt = String("saltsalt12345678").as_bytes()
     var ctx = Argon2id(salt, memory_size_kb=65536, iterations=3, parallelism=4)
-    
+
     _ = ctx.hash(password)
-    
+
     var count = 0
     var start = perf_counter()
     while perf_counter() - start < duration_secs:
@@ -186,27 +252,32 @@ fn benchmark_argon2(duration_secs: Float64) -> String:
     var end = perf_counter()
     var duration = end - start
     var hps = Float64(count) / duration
-    return "argon2id | throughput: " + String(hps)[:6] + " h/s, hashes: " + String(count) + ", time: " + String(duration)[:4] + "s"
+    return String(
+        "argon2id | throughput: ",
+        round(hps, 6),
+        " h/s, hashes: ",
+        count,
+        ", time: ",
+        round(duration, 4),
+        "s"
+    )
 
 
 def main():
-    print("Thistle benchmark:")
-    print()
-    print("Testing.... please wait for all the tests to conclude.")
-    print()
-    
-    var data = generate_data(100 * 1024 * 1024)
+    print("Thistle benchmark:\n")
+    print("Testing.... please wait for all the tests to conclude.\n")
+
+    var data = generate_data(100 * _MiB)
     var duration = 5.0
-    
-    print(benchmark_sha256(data, duration))
-    print(benchmark_sha512(data, duration))
-    print(benchmark_sha3_256(data, duration))
-    print(benchmark_blake2b(data, duration))
+
+    # print(benchmark_sha256(data, duration))
+    # print(benchmark_sha512(data, duration))
+    # print(benchmark_sha3_256(data, duration))
+    # print(benchmark_blake2b(data, duration))
     print(benchmark_blake3(data, duration))
-    print(benchmark_camellia(1024 * 1024, duration))
-    print(benchmark_chacha20(1024 * 1024, duration))
-    print(benchmark_kcipher2(1024 * 1024, duration))
-    print(benchmark_argon2(duration))
-    
-    print()
-    print("All benchmarks completed")
+    # print(benchmark_camellia(_MiB, duration))
+    # print(benchmark_chacha20(_MiB, duration))
+    # print(benchmark_kcipher2(_MiB, duration))
+    # print(benchmark_argon2(duration))
+
+    print("\nAll benchmarks completed")

--- a/tests/benchmark.mojo
+++ b/tests/benchmark.mojo
@@ -270,14 +270,14 @@ def main():
     var data = generate_data(100 * _MiB)
     var duration = 5.0
 
-    # print(benchmark_sha256(data, duration))
-    # print(benchmark_sha512(data, duration))
-    # print(benchmark_sha3_256(data, duration))
-    # print(benchmark_blake2b(data, duration))
+    print(benchmark_sha256(data, duration))
+    print(benchmark_sha512(data, duration))
+    print(benchmark_sha3_256(data, duration))
+    print(benchmark_blake2b(data, duration))
     print(benchmark_blake3(data, duration))
-    # print(benchmark_camellia(_MiB, duration))
-    # print(benchmark_chacha20(_MiB, duration))
-    # print(benchmark_kcipher2(_MiB, duration))
-    # print(benchmark_argon2(duration))
+    print(benchmark_camellia(_MiB, duration))
+    print(benchmark_chacha20(_MiB, duration))
+    print(benchmark_kcipher2(_MiB, duration))
+    print(benchmark_argon2(duration))
 
     print("\nAll benchmarks completed")

--- a/tests/thistle_test_vectors.mojo
+++ b/tests/thistle_test_vectors.mojo
@@ -183,7 +183,7 @@ fn test_blake3(json_data: PythonObject, py: PythonObject) raises -> TestResult:
             passed += 1
         else:
             failed += 1
-            failures.append("BLAKE3 " + String(input_len) + " bytes: expected " + expected + ", got " + got)
+            failures.append(String("BLAKE3 ", input_len, " bytes: expected ", expected, ", got ", got))
     
     return TestResult(passed, failed, failures^)
 


### PR DESCRIPTION
Create a new `StackInlineArray` structure that just wraps `stack_allocation` and use it in blake3 to simplify a lot of code. Also add performance improvements by unrolling some loops at compile time