### PR TITLE
Marginally improve blake3 performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ libs/*.dylib
 *.dylib
 build/
 .pixi/
+kgen.trace.*


### PR DESCRIPTION
Marginally improve perf in blake 3 by unrolling a loop, vectorizing a store, and avoiding an unnecessary memset to zero. Took the opportunity to polish some code.


## Benchmark results

CPU: Intel i7-7700HQ

old:
blake3 | throughput: 7994.8 mb/s, hashes: 160, time: 2.00s

new:
blake3 | throughput: 8226.8 mb/s, hashes: 165, time: 2.00s
