### PR TITLE
Thistle 1.0.4

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Thistle was written to avoid the **150x performance drops** when Mojo has to cal
 * **ChaCha20**
 * **KCipher-2**
 * **ML-KEM/ML-DSA**
-* **AES-GPU** (CBC/ECB/CTR/GCM/ECB/CTR)
+* **AES-GPU** (ECB/CTR/GCM)
 * **AES-NI** (XTS/CBC/ECB/CTR/GCM/ECB/CTR)
 * **AES-Software** (XTS/CBC/ECB/CTR/GCM/ECB/CTR)
 * **ECDSA** (ED25519/X25519)

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Thistle was written to avoid the **150x performance drops** when Mojo has to cal
 * **ChaCha20**
 * **KCipher-2**
 * **ML-KEM/ML-DSA**
-* **AES-GPU** (XTS/CBC/ECB/CTR/GCM/ECB/CTR)
+* **AES-GPU** (CBC/ECB/CTR/GCM/ECB/CTR)
 * **AES-NI** (XTS/CBC/ECB/CTR/GCM/ECB/CTR)
 * **AES-Software** (XTS/CBC/ECB/CTR/GCM/ECB/CTR)
 * **ECDSA** (ED25519/X25519)

--- a/src/thistle/__init__.mojo
+++ b/src/thistle/__init__.mojo
@@ -7,7 +7,7 @@ from . import fips
 from .aes import AESKey, expand_key_128, expand_key_192, expand_key_256, SBOX, ROUNDS_128
 from .aes import gf_mul2, gf_mul3, sbox_lookup, sub_word
 from .aes import ttable0, ttable1, ttable2, ttable3
-from .aes_gpu import aes_kernel
+from .aes_gpu import aes_gpu_kernel_ecb, aes_gpu_kernel_ctr, aes_gpu_kernel_gcm
 from .aes_ni import has_aes_ni, has_x86_aes_ni, has_arm_crypto
 from .aes_ni import arm_aes_encrypt_128, arm_aes_encrypt_192, arm_aes_encrypt_256
 from .aes_ni import x86_aes_encrypt_128, x86_aes_encrypt_256

--- a/src/thistle/__init__.mojo
+++ b/src/thistle/__init__.mojo
@@ -1,7 +1,4 @@
-# ===----------------------------------------------------------------------=== #
-# Thistle Cryptography Library
-# Primary API Entry Point
-# ===----------------------------------------------------------------------=== #
+# Thistle public API
 
 from . import fips
 from .aes import AESKey, expand_key_128, expand_key_192, expand_key_256, SBOX, ROUNDS_128
@@ -27,5 +24,5 @@ from .ml_kem import mlkem512_keygen, mlkem768_keygen, mlkem1024_keygen
 from .ml_kem import mlkem512_encaps, mlkem768_encaps, mlkem1024_encaps
 from .ml_kem import mlkem512_decaps, mlkem768_decaps, mlkem1024_decaps
 
-comptime VERSION = "1.0.3"
+comptime VERSION = "1.0.4"
 comptime AUTHOR = "Libalpm64, Lostlab Technologies"

--- a/src/thistle/aes.mojo
+++ b/src/thistle/aes.mojo
@@ -238,6 +238,7 @@ def _cpu_aes_encrypt[rounds: Int](
     pt_bytes.store(15, s15)
 
 @always_inline
+# Not Constant Time
 def cpu_aes_encrypt(
     pt_bytes: UnsafePointer[UInt8, MutAnyOrigin],
     round_keys: UnsafePointer[UInt32, MutAnyOrigin],

--- a/src/thistle/aes.mojo
+++ b/src/thistle/aes.mojo
@@ -1,10 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 AES CPU implementation
-By Libalpm64 no attribution required.
-Work in progress.
 """
 
 from std.memory import alloc

--- a/src/thistle/aes_gpu.mojo
+++ b/src/thistle/aes_gpu.mojo
@@ -6,13 +6,11 @@ AES-GPU implementation
 By Libalpm64 no attribution required.
 """
 
-from std.gpu import global_idx, thread_idx, block_dim, barrier
+from std.gpu import global_idx
 from std.memory import stack_allocation
 from std.memory import AddressSpace
 from std.memory.unsafe_pointer import UnsafePointer
 from std.utils import StaticTuple
-
-comptime MAX_WG_SIZE = 1024
 
 @always_inline
 def gpu_gf_mul2(a: UInt8) -> UInt8:
@@ -280,14 +278,6 @@ def incr_counter(mut counter: StaticTuple[UInt8, 16]) -> None:
         if carry == 0:
             break
 
-def xts_mul_alpha(tweak: UnsafePointer[UInt8, MutAnyOrigin]) -> None:
-    var high_bit = (tweak[15] & 0x80) != 0
-    for i in range(15, 0, -1):
-        tweak[i] = (tweak[i] << UInt8(1)) | (tweak[i - 1] >> UInt8(7))
-    tweak[0] = tweak[0] << UInt8(1)
-    if high_bit:
-        tweak[0] = tweak[0] ^ UInt8(0x87)
-
 @always_inline
 def aes_gpu_kernel_ecb(
     input_data: UnsafePointer[UInt8, MutAnyOrigin],
@@ -374,64 +364,4 @@ def aes_gpu_kernel_gcm(
     else:
         aes_encrypt_ctr[14](bp, op, round_keys_data, sbox_buffer, 1, counter, scratch.address_space_cast[AddressSpace.GENERIC]())
 
-@always_inline
-def aes_gpu_kernel_xts(
-    input_data: UnsafePointer[UInt8, MutAnyOrigin],
-    output_data: UnsafePointer[UInt8, MutAnyOrigin],
-    round_keys_data1: UnsafePointer[UInt32, MutAnyOrigin],
-    round_keys_data2: UnsafePointer[UInt32, MutAnyOrigin],
-    sbox_buffer: UnsafePointer[UInt8, MutAnyOrigin],
-    n: Int,
-    tweak: UnsafePointer[UInt8, MutAnyOrigin],
-    rounds: Int,
-) -> None:
-    var tid = global_idx.x
-    if tid >= n:
-        return
-    var bp = input_data + tid * 16
-    var op = output_data + tid * 16
-    var local_tid = thread_idx.x
 
-    var wg_size = block_dim.x
-    var shared_tweaks = stack_allocation[MAX_WG_SIZE * 16, UInt8, address_space=AddressSpace.SHARED]()
-
-    var base_tweak = stack_allocation[16, UInt8, address_space=AddressSpace.LOCAL]()
-    if rounds == 10:
-        aes_encrypt_ecb[10](tweak, base_tweak.address_space_cast[AddressSpace.GENERIC](), round_keys_data2, sbox_buffer, 1)
-    elif rounds == 12:
-        aes_encrypt_ecb[12](tweak, base_tweak.address_space_cast[AddressSpace.GENERIC](), round_keys_data2, sbox_buffer, 1)
-    else:
-        aes_encrypt_ecb[14](tweak, base_tweak.address_space_cast[AddressSpace.GENERIC](), round_keys_data2, sbox_buffer, 1)
-
-    if local_tid == 0:
-        var cur_ptr = shared_tweaks
-        for j in range(16):
-            cur_ptr[j] = base_tweak[j]
-        var base_tid = global_idx.x
-        for _ in range(base_tid):
-            xts_mul_alpha(cur_ptr.address_space_cast[AddressSpace.GENERIC]())
-        for i in range(1, wg_size):
-            var prev_ptr = cur_ptr
-            cur_ptr = shared_tweaks + i * 16
-            for j in range(16):
-                cur_ptr[j] = prev_ptr[j]
-            xts_mul_alpha(cur_ptr.address_space_cast[AddressSpace.GENERIC]())
-
-    barrier()
-
-    var my_tweak = shared_tweaks + local_tid * 16
-
-    var tmp = stack_allocation[16, UInt8, address_space=AddressSpace.LOCAL]()
-    for j in range(16):
-        tmp[j] = bp[j] ^ my_tweak[j]
-
-    var enc_tmp = stack_allocation[16, UInt8, address_space=AddressSpace.LOCAL]()
-    if rounds == 10:
-        aes_encrypt_ecb[10](tmp.address_space_cast[AddressSpace.GENERIC](), enc_tmp.address_space_cast[AddressSpace.GENERIC](), round_keys_data1, sbox_buffer, 1)
-    elif rounds == 12:
-        aes_encrypt_ecb[12](tmp.address_space_cast[AddressSpace.GENERIC](), enc_tmp.address_space_cast[AddressSpace.GENERIC](), round_keys_data1, sbox_buffer, 1)
-    else:
-        aes_encrypt_ecb[14](tmp.address_space_cast[AddressSpace.GENERIC](), enc_tmp.address_space_cast[AddressSpace.GENERIC](), round_keys_data1, sbox_buffer, 1)
-
-    for j in range(16):
-        op[j] = enc_tmp[j] ^ my_tweak[j]

--- a/src/thistle/aes_gpu.mojo
+++ b/src/thistle/aes_gpu.mojo
@@ -1,9 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 AES-GPU implementation
-By Libalpm64 no attribution required.
 """
 
 from std.gpu import global_idx

--- a/src/thistle/aes_gpu.mojo
+++ b/src/thistle/aes_gpu.mojo
@@ -6,11 +6,13 @@ AES-GPU implementation
 By Libalpm64 no attribution required.
 """
 
-from std.gpu import global_idx
+from std.gpu import global_idx, thread_idx, block_dim, barrier
 from std.memory import stack_allocation
 from std.memory import AddressSpace
 from std.memory.unsafe_pointer import UnsafePointer
 from std.utils import StaticTuple
+
+comptime MAX_WG_SIZE = 1024
 
 @always_inline
 def gpu_gf_mul2(a: UInt8) -> UInt8:
@@ -388,22 +390,40 @@ def aes_gpu_kernel_xts(
         return
     var bp = input_data + tid * 16
     var op = output_data + tid * 16
+    var local_tid = thread_idx.x
 
-    var enc_tweak = stack_allocation[16, UInt8, address_space=AddressSpace.LOCAL]()
+    var wg_size = block_dim.x
+    var shared_tweaks = stack_allocation[MAX_WG_SIZE * 16, UInt8, address_space=AddressSpace.SHARED]()
+
+    var base_tweak = stack_allocation[16, UInt8, address_space=AddressSpace.LOCAL]()
     if rounds == 10:
-        aes_encrypt_ecb[10](tweak, enc_tweak.address_space_cast[AddressSpace.GENERIC](), round_keys_data2, sbox_buffer, 1)
+        aes_encrypt_ecb[10](tweak, base_tweak.address_space_cast[AddressSpace.GENERIC](), round_keys_data2, sbox_buffer, 1)
     elif rounds == 12:
-        aes_encrypt_ecb[12](tweak, enc_tweak.address_space_cast[AddressSpace.GENERIC](), round_keys_data2, sbox_buffer, 1)
+        aes_encrypt_ecb[12](tweak, base_tweak.address_space_cast[AddressSpace.GENERIC](), round_keys_data2, sbox_buffer, 1)
     else:
-        aes_encrypt_ecb[14](tweak, enc_tweak.address_space_cast[AddressSpace.GENERIC](), round_keys_data2, sbox_buffer, 1)
+        aes_encrypt_ecb[14](tweak, base_tweak.address_space_cast[AddressSpace.GENERIC](), round_keys_data2, sbox_buffer, 1)
 
-    var enc_tweak_generic = enc_tweak.address_space_cast[AddressSpace.GENERIC]()
-    for _ in range(tid):
-        xts_mul_alpha(enc_tweak_generic)
+    if local_tid == 0:
+        var cur_ptr = shared_tweaks
+        for j in range(16):
+            cur_ptr[j] = base_tweak[j]
+        var base_tid = global_idx.x
+        for _ in range(base_tid):
+            xts_mul_alpha(cur_ptr.address_space_cast[AddressSpace.GENERIC]())
+        for i in range(1, wg_size):
+            var prev_ptr = cur_ptr
+            cur_ptr = shared_tweaks + i * 16
+            for j in range(16):
+                cur_ptr[j] = prev_ptr[j]
+            xts_mul_alpha(cur_ptr.address_space_cast[AddressSpace.GENERIC]())
+
+    barrier()
+
+    var my_tweak = shared_tweaks + local_tid * 16
 
     var tmp = stack_allocation[16, UInt8, address_space=AddressSpace.LOCAL]()
     for j in range(16):
-        tmp[j] = bp[j] ^ enc_tweak[j]
+        tmp[j] = bp[j] ^ my_tweak[j]
 
     var enc_tmp = stack_allocation[16, UInt8, address_space=AddressSpace.LOCAL]()
     if rounds == 10:
@@ -414,4 +434,4 @@ def aes_gpu_kernel_xts(
         aes_encrypt_ecb[14](tmp.address_space_cast[AddressSpace.GENERIC](), enc_tmp.address_space_cast[AddressSpace.GENERIC](), round_keys_data1, sbox_buffer, 1)
 
     for j in range(16):
-        op[j] = enc_tmp[j] ^ enc_tweak[j]
+        op[j] = enc_tmp[j] ^ my_tweak[j]

--- a/src/thistle/aes_ni.mojo
+++ b/src/thistle/aes_ni.mojo
@@ -1,9 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 AES-NI implementation
-By Libalpm64 no attribution required.
 """
 
 from std.sys import llvm_intrinsic, CompilationTarget

--- a/src/thistle/argon2.mojo
+++ b/src/thistle/argon2.mojo
@@ -1,10 +1,6 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 Argon2id/Argon2d Implementation in Mojo
 RFC 9106
-By Libalpm64 no attribution required.
 """
 
 from std.collections import List
@@ -393,12 +389,12 @@ def _validate_params(parallelism: Int, tag_length: Int, memory_size_kb: Int, ite
     # RFC 9106 section 3 parameter bounds
     if parallelism < 1 or parallelism >= (1 << 24):
         raise Error("Argon2 parallelism must be in [1, 2^24)")
-    if tag_length < 4:
-        raise Error("Argon2 tag length must be at least 4")
-    if memory_size_kb < 8 * parallelism:
-        raise Error("Argon2 memory must be at least 8*parallelism KiB")
-    if iterations < 1:
-        raise Error("Argon2 iterations must be at least 1")
+    if tag_length < 4 or tag_length >= (1 << 32):
+        raise Error("Argon2 tag length must be in [4, 2^32)")
+    if memory_size_kb < 8 * parallelism or memory_size_kb >= (1 << 32):
+        raise Error("Argon2 memory must be in [8*parallelism, 2^32) KiB")
+    if iterations < 1 or iterations >= (1 << 32):
+        raise Error("Argon2 iterations must be in [1, 2^32)")
 
 
 struct Argon2id:

--- a/src/thistle/argon2.mojo
+++ b/src/thistle/argon2.mojo
@@ -389,6 +389,18 @@ def _argon2_process_lane(
     zero_and_free_u64(zero_u64, 128)
     zero_and_free_u64(tmp_addr, 128)
 
+def _validate_params(parallelism: Int, tag_length: Int, memory_size_kb: Int, iterations: Int) raises:
+    # RFC 9106 section 3 parameter bounds
+    if parallelism < 1 or parallelism >= (1 << 24):
+        raise Error("Argon2 parallelism must be in [1, 2^24)")
+    if tag_length < 4:
+        raise Error("Argon2 tag length must be at least 4")
+    if memory_size_kb < 8 * parallelism:
+        raise Error("Argon2 memory must be at least 8*parallelism KiB")
+    if iterations < 1:
+        raise Error("Argon2 iterations must be at least 1")
+
+
 struct Argon2id:
     var parallelism: Int
     var tag_length: Int
@@ -408,7 +420,8 @@ struct Argon2id:
         memory_size_kb: Int = 65536,
         iterations: Int = 3,
         version: Int = 0x13,
-    ):
+    ) raises:
+        _validate_params(parallelism, tag_length, memory_size_kb, iterations)
         self.parallelism = parallelism
         self.tag_length = tag_length
         self.memory_size_kb = memory_size_kb
@@ -431,7 +444,8 @@ struct Argon2id:
         memory_size_kb: Int = 65536,
         iterations: Int = 3,
         version: Int = 0x13,
-    ):
+    ) raises:
+        _validate_params(parallelism, tag_length, memory_size_kb, iterations)
         self.parallelism = parallelism
         self.tag_length = tag_length
         self.memory_size_kb = memory_size_kb
@@ -553,7 +567,7 @@ struct Argon2id:
         zero_and_free(c_bytes, 1024)
         return result^
 
-def argon2id_hash_string(password: String, salt: String) -> String:
+def argon2id_hash_string(password: String, salt: String) raises -> String:
     var p_bytes = password.as_bytes()
     var s_bytes = salt.as_bytes()
     var ctx = Argon2id(s_bytes)

--- a/src/thistle/blake2b.mojo
+++ b/src/thistle/blake2b.mojo
@@ -98,6 +98,7 @@ struct Blake2b(Movable):
     var key_len: Int
 
     def __init__(out self, out_len: Int = 64):
+        debug_assert(1 <= out_len <= 64, "BLAKE2b digest length must be 1..64")
         self.out_len = out_len
         self.key_len = 0
         self.h = BLAKE2B_IV
@@ -115,6 +116,8 @@ struct Blake2b(Movable):
         self.h[0] ^= p0
 
     def __init__(out self, out_len: Int, key: Span[UInt8, ...]):
+        debug_assert(1 <= out_len <= 64, "BLAKE2b digest length must be 1..64")
+        debug_assert(len(key) <= 64, "BLAKE2b key must be at most 64 bytes")
         self.out_len = out_len
         self.key_len = len(key)
         self.h = BLAKE2B_IV
@@ -274,7 +277,9 @@ def string_to_bytes(s: String) -> List[UInt8]:
     return data^
 
 
-def blake2b_hash(data: Span[UInt8, ...], out_len: Int = 64) -> List[UInt8]:
+def blake2b_hash(data: Span[UInt8, ...], out_len: Int = 64) raises -> List[UInt8]:
+    if out_len < 1 or out_len > 64:
+        raise Error("BLAKE2b digest length must be 1..64")
     var ctx = Blake2b(out_len)
     ctx.update(data)
     return ctx.finalize()
@@ -282,13 +287,17 @@ def blake2b_hash(data: Span[UInt8, ...], out_len: Int = 64) -> List[UInt8]:
 
 def blake2b_hash_keyed(
     data: Span[UInt8, ...], key: Span[UInt8, ...], out_len: Int = 64
-) -> List[UInt8]:
+) raises -> List[UInt8]:
+    if out_len < 1 or out_len > 64:
+        raise Error("BLAKE2b digest length must be 1..64")
+    if len(key) > 64:
+        raise Error("BLAKE2b key must be at most 64 bytes")
     var ctx = Blake2b(out_len, key)
     ctx.update(data)
     return ctx.finalize()
 
 
-def blake2b_hash_string(s: String, out_len: Int = 64) -> String:
+def blake2b_hash_string(s: String, out_len: Int = 64) raises -> String:
     var data = string_to_bytes(s)
     var hash = blake2b_hash(Span[UInt8, ...](data), out_len)
     return bytes_to_hex(hash)

--- a/src/thistle/blake2b.mojo
+++ b/src/thistle/blake2b.mojo
@@ -1,10 +1,6 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 BLAKE2b Implementation in Mojo
 RFC 7693
-By Libalpm64, Attribute not required.
 """
 
 from std.collections import List

--- a/src/thistle/blake3.mojo
+++ b/src/thistle/blake3.mojo
@@ -1,9 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies, Martinyuvk.
-
 """
 BLAKE3 cryptographic hash function
-By Libalpm64, Martinvuyk no attribution required.
 """
 
 from std.algorithm import parallelize
@@ -180,24 +176,6 @@ def compress_internal[
     )
 
 @always_inline
-def g_vertical(
-    mut a: SIMD[DType.uint32, 8],
-    mut b: SIMD[DType.uint32, 8],
-    mut c: SIMD[DType.uint32, 8],
-    mut d: SIMD[DType.uint32, 8],
-    x: SIMD[DType.uint32, 8],
-    y: SIMD[DType.uint32, 8],
-):
-    a = a + b + x
-    d = bit_rotr[16, 8](d ^ a)
-    c = c + d
-    b = bit_rotr[12, 8](b ^ c)
-    a = a + b + y
-    d = bit_rotr[8, 8](d ^ a)
-    c = c + d
-    b = bit_rotr[7, 8](b ^ c)
-
-@always_inline
 def compress_core(
     cv: SIMD[DType.uint32, 8],
     block: SIMD[DType.uint32, 16],
@@ -316,9 +294,7 @@ def compress_parallel_8(
         for v_idx in range(len(_v_idxes_arr)):
             comptime v_i = _v_idxes_arr[v_idx]
             comptime m_i = round_idxes[v_idx]
-            g_vertical(
-                v[v_i[0]], v[v_i[1]], v[v_i[2]], v[v_i[3]], m[m_i[0]], m[m_i[1]]
-            )
+            g_idx[8, v_i[0], v_i[1], v_i[2], v_i[3]](v, m[m_i[0]], m[m_i[1]])
 
     out_ptr[0] = v[0] ^ v[8]
     out_ptr[1] = v[1] ^ v[9]
@@ -395,12 +371,8 @@ def compress_parallel_16_per_lane(
         for v_idx in range(len(_v_idxes_arr)):
             comptime v = _v_idxes_arr[v_idx]
             comptime m_i = round_idxes[v_idx]
-            g_vertical(
-                va[v[0]], va[v[1]], va[v[2]], va[v[3]], ma[m_i[0]], ma[m_i[1]]
-            )
-            g_vertical(
-                vb[v[0]], vb[v[1]], vb[v[2]], vb[v[3]], mb[m_i[0]], mb[m_i[1]]
-            )
+            g_idx[8, v[0], v[1], v[2], v[3]](va, ma[m_i[0]], ma[m_i[1]])
+            g_idx[8, v[0], v[1], v[2], v[3]](vb, mb[m_i[0]], mb[m_i[1]])
 
     var res_a: StackInlineArray[SIMD[DType.uint32, 8], 8] = [
         va[0] ^ va[8],

--- a/src/thistle/blake3.mojo
+++ b/src/thistle/blake3.mojo
@@ -105,6 +105,26 @@ def g_v[
     g_v_half1[w](a, b, c, d, x)
     g_v_half2[w](a, b, c, d, y)
 
+
+@always_inline
+def g_idx[
+    w: Int, ai: Int, bi: Int, ci: Int, di: Int
+](
+    mut v: StackInlineArray[SIMD[DType.uint32, w], 16],
+    x: SIMD[DType.uint32, w],
+    y: SIMD[DType.uint32, w],
+):
+    # copy in/out so we never hold two mut refs into the same array
+    var a = v[ai]
+    var b = v[bi]
+    var c = v[ci]
+    var d = v[di]
+    g_v[w](a, b, c, d, x, y)
+    v[ai] = a
+    v[bi] = b
+    v[ci] = c
+    v[di] = d
+
 @always_inline
 def compress_internal[
     w: Int
@@ -131,14 +151,14 @@ def compress_internal[
     @parameter
     @always_inline
     def round():
-        g_v(v[0], v[4], v[8], v[12], m[0], m[1])
-        g_v(v[1], v[5], v[9], v[13], m[2], m[3])
-        g_v(v[2], v[6], v[10], v[14], m[4], m[5])
-        g_v(v[3], v[7], v[11], v[15], m[6], m[7])
-        g_v(v[0], v[5], v[10], v[15], m[8], m[9])
-        g_v(v[1], v[6], v[11], v[12], m[10], m[11])
-        g_v(v[2], v[7], v[8], v[13], m[12], m[13])
-        g_v(v[3], v[4], v[9], v[14], m[14], m[15])
+        g_idx[w, 0, 4, 8, 12](v, m[0], m[1])
+        g_idx[w, 1, 5, 9, 13](v, m[2], m[3])
+        g_idx[w, 2, 6, 10, 14](v, m[4], m[5])
+        g_idx[w, 3, 7, 11, 15](v, m[6], m[7])
+        g_idx[w, 0, 5, 10, 15](v, m[8], m[9])
+        g_idx[w, 1, 6, 11, 12](v, m[10], m[11])
+        g_idx[w, 2, 7, 8, 13](v, m[12], m[13])
+        g_idx[w, 3, 4, 9, 14](v, m[14], m[15])
     
     @parameter
     @always_inline
@@ -232,14 +252,14 @@ def compress_internal_16way(
     @parameter
     @always_inline
     def round():
-        g_v[16](v[0], v[4], v[8], v[12], m[0], m[1])
-        g_v[16](v[1], v[5], v[9], v[13], m[2], m[3])
-        g_v[16](v[2], v[6], v[10], v[14], m[4], m[5])
-        g_v[16](v[3], v[7], v[11], v[15], m[6], m[7])
-        g_v[16](v[0], v[5], v[10], v[15], m[8], m[9])
-        g_v[16](v[1], v[6], v[11], v[12], m[10], m[11])
-        g_v[16](v[2], v[7], v[8], v[13], m[12], m[13])
-        g_v[16](v[3], v[4], v[9], v[14], m[14], m[15])
+        g_idx[16, 0, 4, 8, 12](v, m[0], m[1])
+        g_idx[16, 1, 5, 9, 13](v, m[2], m[3])
+        g_idx[16, 2, 6, 10, 14](v, m[4], m[5])
+        g_idx[16, 3, 7, 11, 15](v, m[6], m[7])
+        g_idx[16, 0, 5, 10, 15](v, m[8], m[9])
+        g_idx[16, 1, 6, 11, 12](v, m[10], m[11])
+        g_idx[16, 2, 7, 8, 13](v, m[12], m[13])
+        g_idx[16, 3, 4, 9, 14](v, m[14], m[15])
 
     @parameter
     @always_inline

--- a/src/thistle/camellia.mojo
+++ b/src/thistle/camellia.mojo
@@ -1,9 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 Camellia block cipher implementation per RFC 3713
-By Libalpm no attribution required
 """
 
 from std.memory import bitcast, UnsafePointer

--- a/src/thistle/camellia.mojo
+++ b/src/thistle/camellia.mojo
@@ -6,7 +6,7 @@ Camellia block cipher implementation per RFC 3713
 By Libalpm no attribution required
 """
 
-from std.memory import bitcast
+from std.memory import bitcast, UnsafePointer
 from std.bit import byte_swap, rotate_bits_left
 from std.collections import InlineArray
 from std.utils import StaticTuple
@@ -206,22 +206,28 @@ struct CamelliaCipher:
     var ke: InlineArray[UInt64, 6]
     var is_128: Bool
     
-    def __init__(out self, key: Span[UInt8, ...]):
+    def __init__(out self, key: Span[UInt8, ...]) raises:
         self.kw = SIMD[DType.uint64, 4](0)
-        self.k = InlineArray[UInt64, 24](uninitialized=True)
-        self.ke = InlineArray[UInt64, 6](uninitialized=True)
-        for i in range(24):
-            self.k[i] = 0
-        for i in range(6):
-            self.ke[i] = 0
+        self.k = InlineArray[UInt64, 24](fill=0)
+        self.ke = InlineArray[UInt64, 6](fill=0)
         self.is_128 = len(key) == 16
-        
+
         if self.is_128:
             self._key_schedule_128(key)
         elif len(key) == 24 or len(key) == 32:
             self._key_schedule_192_256(key)
         else:
-            print("Error: Invalid key length. Must be 16, 24, or 32 bytes.")
+            raise Error("Camellia key must be 16, 24, or 32 bytes")
+
+    def wipe(mut self):
+        var kw_ptr = UnsafePointer(to=self.kw).bitcast[UInt64]()
+        kw_ptr.store[volatile=True](0, SIMD[DType.uint64, 4](0))
+        var k_ptr = self.k.unsafe_ptr()
+        for i in range(24):
+            k_ptr.store[volatile=True](i, UInt64(0))
+        var ke_ptr = self.ke.unsafe_ptr()
+        for i in range(6):
+            ke_ptr.store[volatile=True](i, UInt64(0))
 
     @always_inline
     def _bytes_to_u64_be(ref self, b: Span[UInt8, ...]) -> UInt64:
@@ -485,8 +491,12 @@ struct CamelliaCipher:
         
         return bitcast[DType.uint8, 16](SIMD[DType.uint64, 2](byte_swap(d1), byte_swap(d2)))
 
-    def encrypt(self, block: Span[UInt8, ...]) -> SIMD[DType.uint8, 16]:
+    def encrypt(self, block: Span[UInt8, ...]) raises -> SIMD[DType.uint8, 16]:
+        if len(block) < 16:
+            raise Error("Camellia block must be 16 bytes")
         return self.encrypt(block.unsafe_ptr().load[width=16, alignment=1](0))
 
-    def decrypt(self, block: Span[UInt8, ...]) -> SIMD[DType.uint8, 16]:
+    def decrypt(self, block: Span[UInt8, ...]) raises -> SIMD[DType.uint8, 16]:
+        if len(block) < 16:
+            raise Error("Camellia block must be 16 bytes")
         return self.decrypt(block.unsafe_ptr().load[width=16, alignment=1](0))

--- a/src/thistle/chacha20.mojo
+++ b/src/thistle/chacha20.mojo
@@ -336,13 +336,22 @@ struct ChaCha20:
         self.nonce = bitcast[DType.uint32, 3](nonce_bytes)
         self.counter = counter
 
+    def _check_counter_space(self, data_len: Int) raises:
+        var blocks_needed = UInt64((data_len + 63) // 64)
+        var space = UInt64(0x100000000) - UInt64(self.counter)
+        if blocks_needed > space:
+            raise Error("ChaCha20 counter would wrap; use a new nonce")
+
     def encrypt_into[origin: Origin[mut=True]](
         mut self,
         plaintext: Span[UInt8, ...],
         mut ciphertext: Span[mut=True, UInt8, origin],
-    ):
+    ) raises:
         """Encrypt plaintext into caller-owned ciphertext storage and advance counter."""
         var len_pt = len(plaintext)
+        if len(ciphertext) < len_pt:
+            raise Error("ChaCha20 ciphertext buffer too small")
+        self._check_counter_space(len_pt)
         var ciphertext_ptr = ciphertext.unsafe_ptr()
         var block_idx = 0
         var offset = 0
@@ -384,14 +393,15 @@ struct ChaCha20:
         mut self,
         ciphertext: Span[UInt8, ...],
         mut plaintext: Span[mut=True, UInt8, origin],
-    ):
+    ) raises:
         self.encrypt_into(ciphertext, plaintext)
 
     def encrypt_inplace[origin: Origin[mut=True]](
         mut self, mut data: Span[mut=True, UInt8, origin]
-    ):
+    ) raises:
         """Encrypt/decrypt in place and advance counter."""
         var len_data = len(data)
+        self._check_counter_space(len_data)
         var data_ptr = data.unsafe_ptr()
         var block_idx = 0
         var offset = 0

--- a/src/thistle/chacha20.mojo
+++ b/src/thistle/chacha20.mojo
@@ -1,9 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 ChaCha20 stream cipher implementation per RFC 7539
-By Libalpm no attribution required
 """
 
 from std.memory import bitcast

--- a/src/thistle/constants.mojo
+++ b/src/thistle/constants.mojo
@@ -1,9 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 from .curve25519 import FieldElement51
 
-# Edwards d value (-121665/121666 mod p).
 comptime EDWARDS_D = FieldElement51(
     929955233495203,
     466365720129213,
@@ -11,7 +7,7 @@ comptime EDWARDS_D = FieldElement51(
     2033849074728123,
     1442794654840575,
 )
-# Edwards 2*d value.
+
 comptime EDWARDS_D2 = FieldElement51(
     1859910466990425,
     932731440258426,
@@ -20,7 +16,6 @@ comptime EDWARDS_D2 = FieldElement51(
     633789495995903,
 )
 
-# sqrt(-1) mod p.
 comptime SQRT_M1 = FieldElement51(
     1718705420411056,
     234908883556509,
@@ -28,5 +23,5 @@ comptime SQRT_M1 = FieldElement51(
     2117202627021982,
     765476049583133,
 )
-# (A-2)/4 for Montgomery ladder, RFC 7748 a24 = 121665
+
 comptime APLUS2_OVER_FOUR = FieldElement51(121665, 0, 0, 0, 0)

--- a/src/thistle/curve25519.mojo
+++ b/src/thistle/curve25519.mojo
@@ -1,10 +1,3 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
-"""
-Curve25519 implementation
-By Libalpm64
-"""
 from std.builtin.dtype import DType
 from std.collections import InlineArray
 

--- a/src/thistle/curve25519.mojo
+++ b/src/thistle/curve25519.mojo
@@ -54,6 +54,15 @@ struct FieldElement51(Movable, Copyable, ImplicitlyCopyable):
         self.limbs = limbs
 
     @always_inline
+    def __init__(out self, limbs: SIMD[DType.uint64, 5]):
+        self.limbs = InlineArray[UInt64, 5](uninitialized=True)
+        self.limbs[0] = limbs[0]
+        self.limbs[1] = limbs[1]
+        self.limbs[2] = limbs[2]
+        self.limbs[3] = limbs[3]
+        self.limbs[4] = limbs[4]
+
+    @always_inline
     def __copyinit__(out self, copy: Self):
         self.limbs = copy.limbs
 
@@ -201,8 +210,7 @@ struct FieldElement51(Movable, Copyable, ImplicitlyCopyable):
         var l = limbs
         var MASK = UInt64(0x7FFFFFFFFFFFF)
         
-        # Iterate until there are no more carries
-        for _ in range(5):
+        for _ in range(2):
             l[1] += l[0] >> 51
             l[0] = l[0] & MASK
             l[2] += l[1] >> 51
@@ -350,8 +358,7 @@ struct FieldElement51(Movable, Copyable, ImplicitlyCopyable):
         var l0_out = (l0_final_2.cast[DType.uint64]()) & MASK
         var l1_out = UInt64(l1_final) + carry.cast[DType.uint64]()
         
-        var raw = FieldElement51(l0_out, l1_out, l2_final, l3_final, l4_final)
-        return raw._reduce(raw.limbs)
+        return FieldElement51(l0_out, l1_out, l2_final, l3_final, l4_final)
 
     @always_inline
     def _reduce(self, limbs: InlineArray[UInt64, 5]) -> FieldElement51:
@@ -366,7 +373,9 @@ struct FieldElement51(Movable, Copyable, ImplicitlyCopyable):
         return FieldElement51(l)
 
     @staticmethod
-    def from_bytes_span(bytes: Span[UInt8, ...]) -> FieldElement51:
+    def from_bytes_span(bytes: Span[UInt8, ...]) raises -> FieldElement51:
+        if len(bytes) < 32:
+            raise Error("FieldElement51 input must be at least 32 bytes")
         @always_inline
         def load8(ptr: UnsafePointer[UInt8, _]) -> UInt64:
             return ptr.bitcast[UInt64]().load[width=1, alignment=1]()

--- a/src/thistle/ed25519.mojo
+++ b/src/thistle/ed25519.mojo
@@ -1,9 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 Ed25519 implementation
-By Libalpm64, no attribution required.
 """
 from std.builtin.dtype import DType
 from std.builtin.simd import SIMD
@@ -318,8 +314,7 @@ def edwards_negate(p: EdwardsPoint) -> EdwardsPoint:
 
 @always_inline
 def _ct_select_fe(a: FieldElement51, b: FieldElement51, choice: UInt8) -> FieldElement51:
-    # Constant-time select: returns choice ? b : a using XOR/mask.
-    # Todo: Verify optimized backend code for release targets.
+    # constant-time select via mask
     var mask = UInt64(0) - UInt64(choice)
     var limbs = SIMD[DType.uint64, 5](0, 0, 0, 0, 0)
     for i in range(5):
@@ -448,7 +443,7 @@ def edwards_decode_checked(data: Span[UInt8, ...]) -> DecodeResult:
     return edwards_decode(data, strict=True)
 
 def edwards_decode_verify_compatible(data: Span[UInt8, ...]) -> DecodeResult:
-    # RFC verification decode, no ZIP-215 decoding (relaxed decoding not allowed under RFC strictnes).
+    # strict RFC decoding only, no ZIP-215
     return edwards_decode(data, strict=True)
 
 @no_inline
@@ -540,7 +535,7 @@ def _scalar_mult_base(k: Span[UInt8, ...]) -> EdwardsPoint:
 @no_inline
 def ed25519_generate_public_key(private_key: Span[UInt8, ...], output: UnsafePointer[UInt8, MutAnyOrigin]) raises:
     # RFC 8032 5.1.5: public key A = [pruned SHA512(secret)]B.
-    if len(private_key) < 32:
+    if len(private_key) != 32:
         raise Error("Ed25519 private key must be 32 bytes")
     var hash = InlineArray[UInt8, 64](uninitialized=True)
     var ctx = SHA512Context()
@@ -565,7 +560,7 @@ def ed25519_sign(private_key: Span[UInt8, ...], message: Span[UInt8, ...], outpu
     # RFC 8032 5.1.6 pure Ed25519:
     # r = SHA512(prefix || M), R = [r]B,
     # k = SHA512(R || A || M), S = r + k*s mod L.
-    if len(private_key) < 32:
+    if len(private_key) != 32:
         raise Error("Ed25519 private key must be 32 bytes")
     var hash = InlineArray[UInt8, 64](uninitialized=True)
     var ctx = SHA512Context()

--- a/src/thistle/ed25519.mojo
+++ b/src/thistle/ed25519.mojo
@@ -10,7 +10,7 @@ from std.builtin.simd import SIMD
 from std.memory import bitcast
 from .curve25519 import FieldElement51
 from .sha2 import SHA512Context, sha512_update, sha512_final_to_buffer
-from .utils import StackInlineArray
+
 
 comptime L_LIMBS = SIMD[DType.uint64, 5](
     0x0002631a5cf5d3ed,
@@ -186,7 +186,7 @@ struct Scalar(Movable, Copyable, ImplicitlyCopyable):
     @staticmethod
     def from_bytes_clamped(bytes: Span[UInt8, ...]) -> Scalar:
         # RFC 8032 5.1.5: prune SHA512(secret)[0..31] into the secret scalar.
-        var s = StackInlineArray[UInt8, 32](uninitialized=True)
+        var s = InlineArray[UInt8, 32](uninitialized=True)
         for i in range(32):
             s[i] = bytes[i]
         s[0] &= 0xF8
@@ -214,13 +214,13 @@ struct Scalar(Movable, Copyable, ImplicitlyCopyable):
 
     @staticmethod
     def _montgomery_mul_raw(a: SIMD[DType.uint64, 5], b: SIMD[DType.uint64, 5]) -> SIMD[DType.uint64, 5]:
-        var z = StackInlineArray[UInt128, 9](uninitialized=True)
+        var z = InlineArray[UInt128, 9](uninitialized=True)
         for i in range(9): z[i] = 0
         for i in range(5):
             for j in range(5):
                 z[i + j] += UInt128(a[i]) * UInt128(b[j])
         var carry: UInt128 = 0
-        var n = StackInlineArray[UInt64, 5](uninitialized=True)
+        var n = InlineArray[UInt64, 5](uninitialized=True)
         for i in range(5):
             var sum = carry + z[i]
             for j in range(i):
@@ -242,6 +242,11 @@ struct Scalar(Movable, Copyable, ImplicitlyCopyable):
         # Montgomery multiplication modulo L.
         var r = Scalar._montgomery_mul_raw(self.limbs, other.limbs)
         return Scalar(r)._sub(Scalar(L_LIMBS))
+
+    def wipe(mut self):
+        UnsafePointer(to=self.limbs).bitcast[UInt64]().store[volatile=True](
+            0, SIMD[DType.uint64, 5](0, 0, 0, 0, 0)
+        )
 
     def _sub(self, other: Scalar) -> Scalar:
         # Branchless subtract modulo L; used on secret scalar paths.
@@ -381,7 +386,7 @@ def edwards_encode_into(p: EdwardsPoint, output: UnsafePointer[UInt8, MutAnyOrig
     var x = p.X * z_inv
     var y = p.Y * z_inv
     y.to_bytes_into(output)
-    var x_bytes = StackInlineArray[UInt8, 32](uninitialized=True)
+    var x_bytes = InlineArray[UInt8, 32](uninitialized=True)
     x.to_bytes_into(x_bytes.unsafe_ptr())
     var x_parity = x_bytes[0] & 1
     output[31] = output[31] | (x_parity << 7)
@@ -390,7 +395,7 @@ def edwards_encode_into(p: EdwardsPoint, output: UnsafePointer[UInt8, MutAnyOrig
 def edwards_decode(data: Span[UInt8, ...], strict: Bool = True) -> DecodeResult:
     # RFC 8032 5.1.3: strict point decoding.
     # Reject y >= p, invalid square roots, and x == 0 with sign bit set.
-    var y_bytes = StackInlineArray[UInt8, 32](uninitialized=True)
+    var y_bytes = InlineArray[UInt8, 32](uninitialized=True)
     for i in range(32):
         y_bytes[i] = data[i]
     var sign = (y_bytes[31] >> 7) & 1
@@ -409,7 +414,7 @@ def edwards_decode(data: Span[UInt8, ...], strict: Bool = True) -> DecodeResult:
     var x = x_opt.unsafe_value()
 
     # x = 0 has no odd/negative alternate root.
-    var x_zero_bytes = StackInlineArray[UInt8, 32](uninitialized=True)
+    var x_zero_bytes = InlineArray[UInt8, 32](uninitialized=True)
     x.to_bytes_into(x_zero_bytes.unsafe_ptr())
     var x_is_zero = True
     for i in range(32):
@@ -419,14 +424,14 @@ def edwards_decode(data: Span[UInt8, ...], strict: Bool = True) -> DecodeResult:
         return DecodeResult(False, EdwardsPoint())
 
     var x_try = x
-    var x_try_bytes = StackInlineArray[UInt8, 32](uninitialized=True)
+    var x_try_bytes = InlineArray[UInt8, 32](uninitialized=True)
     x_try.to_bytes_into(x_try_bytes.unsafe_ptr())
     if (x_try_bytes[0] & 1) != sign:
         # Choose the root matching the encoded x parity.
         x_try = FieldElement51.ZERO() - x_try
 
     var chk = x_try.square() * v - u
-    var chk_bytes = StackInlineArray[UInt8, 32](uninitialized=True)
+    var chk_bytes = InlineArray[UInt8, 32](uninitialized=True)
     chk.to_bytes_into(chk_bytes.unsafe_ptr())
     var ok = True
     for i in range(32):
@@ -480,8 +485,8 @@ def sqrt_ratio_checked(u: FieldElement51, v: FieldElement51) -> Optional[FieldEl
     var vx2 = x.square() * v
     var diff = vx2 - u
     var diff2 = vx2 + u
-    var diff_bytes = StackInlineArray[UInt8, 32](uninitialized=True)
-    var diff2_bytes = StackInlineArray[UInt8, 32](uninitialized=True)
+    var diff_bytes = InlineArray[UInt8, 32](uninitialized=True)
+    var diff2_bytes = InlineArray[UInt8, 32](uninitialized=True)
     diff.to_bytes_into(diff_bytes.unsafe_ptr())
     diff2.to_bytes_into(diff2_bytes.unsafe_ptr())
     var is_zero = True
@@ -532,48 +537,62 @@ def _scalar_mult_base(k: Span[UInt8, ...]) -> EdwardsPoint:
     var bp = ed25519_base_point()
     return _scalar_mult(k, bp)
 
-def ed25519_generate_public_key(private_key: Span[UInt8, ...], output: UnsafePointer[UInt8, MutAnyOrigin]):
+@no_inline
+def ed25519_generate_public_key(private_key: Span[UInt8, ...], output: UnsafePointer[UInt8, MutAnyOrigin]) raises:
     # RFC 8032 5.1.5: public key A = [pruned SHA512(secret)]B.
-    var hash = StackInlineArray[UInt8, 64](uninitialized=True)
+    if len(private_key) < 32:
+        raise Error("Ed25519 private key must be 32 bytes")
+    var hash = InlineArray[UInt8, 64](uninitialized=True)
     var ctx = SHA512Context()
     sha512_update(ctx, private_key)
     sha512_final_to_buffer(ctx, hash.unsafe_ptr())
     var s = Scalar.from_bytes_clamped(Span[UInt8, ...](ptr=hash.unsafe_ptr(), length=32))
-    var s_bytes = StackInlineArray[UInt8, 32](uninitialized=True)
+    var s_bytes = InlineArray[UInt8, 32](uninitialized=True)
     s.to_bytes_into(s_bytes.unsafe_ptr())
     var pub_point = _scalar_mult_base(Span[UInt8, ...](ptr=s_bytes.unsafe_ptr(), length=32))
     edwards_encode_into(pub_point, output)
+    ctx.wipe()
+    s.wipe()
+    var hash_ptr = hash.unsafe_ptr()
+    var s_ptr = s_bytes.unsafe_ptr()
+    for i in range(64):
+        hash_ptr.store[volatile=True](i, UInt8(0))
+    for i in range(32):
+        s_ptr.store[volatile=True](i, UInt8(0))
 
-def ed25519_sign(private_key: Span[UInt8, ...], message: Span[UInt8, ...], output: UnsafePointer[UInt8, MutAnyOrigin]):
+@no_inline
+def ed25519_sign(private_key: Span[UInt8, ...], message: Span[UInt8, ...], output: UnsafePointer[UInt8, MutAnyOrigin]) raises:
     # RFC 8032 5.1.6 pure Ed25519:
     # r = SHA512(prefix || M), R = [r]B,
     # k = SHA512(R || A || M), S = r + k*s mod L.
-    var hash = StackInlineArray[UInt8, 64](uninitialized=True)
+    if len(private_key) < 32:
+        raise Error("Ed25519 private key must be 32 bytes")
+    var hash = InlineArray[UInt8, 64](uninitialized=True)
     var ctx = SHA512Context()
     sha512_update(ctx, private_key)
     sha512_final_to_buffer(ctx, hash.unsafe_ptr())
     var s_scalar = Scalar.from_bytes_clamped(Span[UInt8, ...](ptr=hash.unsafe_ptr(), length=32))
 
-    var s_bytes = StackInlineArray[UInt8, 32](uninitialized=True)
+    var s_bytes = InlineArray[UInt8, 32](uninitialized=True)
     s_scalar.to_bytes_into(s_bytes.unsafe_ptr())
     var A_point = _scalar_mult_base(Span[UInt8, ...](ptr=s_bytes.unsafe_ptr(), length=32))
-    var A_enc = StackInlineArray[UInt8, 32](uninitialized=True)
+    var A_enc = InlineArray[UInt8, 32](uninitialized=True)
     edwards_encode_into(A_point, A_enc.unsafe_ptr())
 
-    var r_hash = StackInlineArray[UInt8, 64](uninitialized=True)
+    var r_hash = InlineArray[UInt8, 64](uninitialized=True)
     var r_ctx = SHA512Context()
     sha512_update(r_ctx, Span[UInt8, ...](ptr=hash.unsafe_ptr() + 32, length=32))
     sha512_update(r_ctx, message)
     sha512_final_to_buffer(r_ctx, r_hash.unsafe_ptr())
 
     var r_scalar = Scalar.from_bytes_wide(Span[UInt8, ...](ptr=r_hash.unsafe_ptr(), length=64))
-    var r_bytes = StackInlineArray[UInt8, 32](uninitialized=True)
+    var r_bytes = InlineArray[UInt8, 32](uninitialized=True)
     r_scalar.to_bytes_into(r_bytes.unsafe_ptr())
     var R_point = _scalar_mult_base(Span[UInt8, ...](ptr=r_bytes.unsafe_ptr(), length=32))
-    var R_enc = StackInlineArray[UInt8, 32](uninitialized=True)
+    var R_enc = InlineArray[UInt8, 32](uninitialized=True)
     edwards_encode_into(R_point, R_enc.unsafe_ptr())
 
-    var k_hash = StackInlineArray[UInt8, 64](uninitialized=True)
+    var k_hash = InlineArray[UInt8, 64](uninitialized=True)
     var k_ctx = SHA512Context()
     sha512_update(k_ctx, Span[UInt8, ...](ptr=R_enc.unsafe_ptr(), length=32))
     sha512_update(k_ctx, Span[UInt8, ...](ptr=A_enc.unsafe_ptr(), length=32))
@@ -582,12 +601,31 @@ def ed25519_sign(private_key: Span[UInt8, ...], message: Span[UInt8, ...], outpu
 
     var k_scalar = Scalar.from_bytes_wide(Span[UInt8, ...](ptr=k_hash.unsafe_ptr(), length=64))
     var S_scalar = r_scalar + k_scalar * s_scalar
-    var S_bytes = StackInlineArray[UInt8, 32](uninitialized=True)
+    var S_bytes = InlineArray[UInt8, 32](uninitialized=True)
     S_scalar.to_bytes_into(S_bytes.unsafe_ptr())
 
     for i in range(32): output[i] = R_enc[i]
     for i in range(32): output[32 + i] = S_bytes[i]
+    ctx.wipe()
+    r_ctx.wipe()
+    s_scalar.wipe()
+    r_scalar.wipe()
+    var hash_ptr = hash.unsafe_ptr()
+    var s_ptr = s_bytes.unsafe_ptr()
+    var r_ptr = r_hash.unsafe_ptr()
+    var r_bytes_ptr = r_bytes.unsafe_ptr()
+    var k_ptr = k_hash.unsafe_ptr()
+    var S_ptr = S_bytes.unsafe_ptr()
+    for i in range(64):
+        hash_ptr.store[volatile=True](i, UInt8(0))
+        r_ptr.store[volatile=True](i, UInt8(0))
+        k_ptr.store[volatile=True](i, UInt8(0))
+    for i in range(32):
+        s_ptr.store[volatile=True](i, UInt8(0))
+        r_bytes_ptr.store[volatile=True](i, UInt8(0))
+        S_ptr.store[volatile=True](i, UInt8(0))
 
+@no_inline
 def ed25519_verify(public_key: Span[UInt8, ...], message: Span[UInt8, ...], signature: Span[UInt8, ...]) -> Bool:
     # RFC 8032 5.1.7 strict Ed25519 verification.
     # Requires canonical A/R, S < L, and checks [S]B == R + [k]A.
@@ -599,16 +637,16 @@ def ed25519_verify(public_key: Span[UInt8, ...], message: Span[UInt8, ...], sign
         return False
     var A = A_res.p
 
-    var R_enc = StackInlineArray[UInt8, 32](uninitialized=True)
+    var R_enc = InlineArray[UInt8, 32](uninitialized=True)
     for i in range(32): R_enc[i] = signature[i]
 
-    var S_bytes = StackInlineArray[UInt8, 32](uninitialized=True)
+    var S_bytes = InlineArray[UInt8, 32](uninitialized=True)
     for i in range(32): S_bytes[i] = signature[32 + i]
     var S_bytes_span = Span[UInt8, ...](ptr=S_bytes.unsafe_ptr(), length=32)
     if not _s_lt_l(S_bytes_span):
         return False
 
-    var k_hash = StackInlineArray[UInt8, 64](uninitialized=True)
+    var k_hash = InlineArray[UInt8, 64](uninitialized=True)
     var k_ctx = SHA512Context()
     sha512_update(k_ctx, Span[UInt8, ...](ptr=R_enc.unsafe_ptr(), length=32))
     sha512_update(k_ctx, public_key)
@@ -620,7 +658,7 @@ def ed25519_verify(public_key: Span[UInt8, ...], message: Span[UInt8, ...], sign
 
     var SB = _scalar_mult(S_bytes_span, ed25519_base_point())
 
-    var k_bytes = StackInlineArray[UInt8, 32](uninitialized=True)
+    var k_bytes = InlineArray[UInt8, 32](uninitialized=True)
     k_scalar.to_bytes_into(k_bytes.unsafe_ptr())
     var k_bytes_span = Span[UInt8, ...](ptr=k_bytes.unsafe_ptr(), length=32)
     var kA = _scalar_mult(k_bytes_span, A)
@@ -629,8 +667,8 @@ def ed25519_verify(public_key: Span[UInt8, ...], message: Span[UInt8, ...], sign
     if not R_res.ok:
         return False
     var P = edwards_add(R_res.p, kA)
-    var P_enc = StackInlineArray[UInt8, 32](uninitialized=True)
-    var SB_enc = StackInlineArray[UInt8, 32](uninitialized=True)
+    var P_enc = InlineArray[UInt8, 32](uninitialized=True)
+    var SB_enc = InlineArray[UInt8, 32](uninitialized=True)
     edwards_encode_into(P, P_enc.unsafe_ptr())
     edwards_encode_into(SB, SB_enc.unsafe_ptr())
     for i in range(32):

--- a/src/thistle/kcipher2.mojo
+++ b/src/thistle/kcipher2.mojo
@@ -1,9 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 KCipher-2 stream cipher implemented in Mojo.
-By Libalpm no attribution required
 """
 
 from std.utils import StaticTuple

--- a/src/thistle/ml_dsa.mojo
+++ b/src/thistle/ml_dsa.mojo
@@ -1,9 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 ML-DSA implementation in Mojo.
-By Libalpm64, no attribution required.
 
 Security notice:
 ML-DSA is incredibly difficult to implement safely because signing uses rejection sampling
@@ -256,8 +252,7 @@ def _ct_select_u32(false_value: UInt32, true_value: UInt32, choice: UInt32) -> U
     return false_value ^ (mask & (false_value ^ true_value))
 
 
-# Volatile stores are stronger cleanup than std.memory.memset_zero, which is ordinary stores.
-# Note: Still no formal guarantee of safety.
+# volatile stores so the wipe can't be optimized away
 def _zero_list_u8(mut data: List[UInt8]):
     var ptr = data.unsafe_ptr()
     for i in range(len(data)):
@@ -1177,7 +1172,6 @@ def _compute_message_hash(tr: Span[UInt8, ...], msg: Span[UInt8, ...], context: 
     if len(context) > 255:
         raise Error("ML-DSA context too long")
 
-	# Stream buffer from SHAKE_final
     var ctx = SHA3Context(1088)
     sha3_update(ctx, tr)
 
@@ -1351,8 +1345,7 @@ def mldsa_sign_external_mu(priv: MLDSAPrivateKey, mu: Span[UInt8, ...], random: 
     var nonce = shake256(Span[UInt8, ...](ptr=h_input.ptr(), length=h_input.len()), 64)
     _zero_stack_u8(h_input)
 
-    # Signing-attempt scratch is allocated once and reused.
-    # Note: Still not constant time but reduces a lot of "noise".
+    # signing scratch allocated once and reused across attempts
     var y = DSAPolyVec[MAX_L]()
     var y_hat = DSAPolyVec[MAX_L]()
     var w = DSAPolyVec[MAX_K]()

--- a/src/thistle/ml_dsa.mojo
+++ b/src/thistle/ml_dsa.mojo
@@ -300,9 +300,9 @@ def _bytes_equal(a: Span[UInt8, ...], b: Span[UInt8, ...]) -> Bool:
 
 @always_inline
 def _field_reduce_once(a: UInt32) -> UInt32:
-    if a >= Q:
-        return a - Q
-    return a
+    # branchless: runs on secret coefficients
+    var t = a - Q
+    return t + ((UInt32(0) - (t >> 31)) & Q)
 
 
 @always_inline
@@ -349,22 +349,19 @@ def _field_from_montgomery(a: UInt32) -> UInt32:
 
 def _centered_mod(r: UInt32) -> Int32:
     var x = Int32(_field_from_montgomery(r))
-    if x <= Int32(Q // 2):
-        return x
-    return x - Int32(Q)
+    var mask = (Int32(Q // 2) - x) >> 31
+    return x + (mask & (Int32(0) - Int32(Q)))
 
 
 def _infinity_norm(r: UInt32) -> UInt32:
     var x = Int32(_field_from_montgomery(r))
-    if x <= Int32(Q // 2):
-        return UInt32(x)
-    return UInt32(Int32(Q) - x)
+    var mask = (Int32(Q // 2) - x) >> 31
+    return UInt32(x + (mask & (Int32(Q) - 2 * x)))
 
 
 def _abs_i32(x: Int32) -> UInt32:
-    if x < 0:
-        return UInt32(-x)
-    return UInt32(x)
+    var mask = x >> 31
+    return UInt32((x ^ mask) - mask)
 
 
 def _poly_add_into(mut r: List[UInt32], b: List[UInt32]):
@@ -651,25 +648,25 @@ def _decompose32(r: UInt32) -> Tuple[UInt8, Int32]:
     var x = _field_from_montgomery(r)
     var r1 = _high_bits32(x)
     var r0 = Int32(x) - Int32(r1) * 2 * Int32((Q - 1) // 32)
-    if Int32(Q // 2 + 1) <= r0:
-        r0 -= Int32(Q)
+    var mask = (r0 - Int32(Q // 2 + 1)) >> 31
+    r0 -= ~mask & Int32(Q)
     return (r1, r0)
 
 
 def _high_bits88(x: UInt32) -> UInt8:
     var r1 = (x + 127) >> 7
     r1 = (r1 * 11275 + (1 << 23)) >> 24
-    if r1 == 44:
-        r1 = 0
-    return UInt8(r1)
+    var d = r1 ^ 44
+    var nonzero_mask = UInt32(0) - ((d | (UInt32(0) - d)) >> 31)
+    return UInt8(r1 & nonzero_mask)
 
 
 def _decompose88(r: UInt32) -> Tuple[UInt8, Int32]:
     var x = _field_from_montgomery(r)
     var r1 = _high_bits88(x)
     var r0 = Int32(x) - Int32(r1) * 2 * Int32((Q - 1) // 88)
-    if Int32(Q // 2 + 1) <= r0:
-        r0 -= Int32(Q)
+    var mask = (r0 - Int32(Q // 2 + 1)) >> 31
+    r0 -= ~mask & Int32(Q)
     return (r1, r0)
 
 

--- a/src/thistle/ml_kem.mojo
+++ b/src/thistle/ml_kem.mojo
@@ -484,7 +484,7 @@ def poly_frombytes(mut r: Poly, a: Span[UInt8, ...]) raises -> Bool:
         var t = _u24_le(a, 3 * i)
         r.coeffs[2 * i] = Int16(t & 0xFFF)
         r.coeffs[2 * i + 1] = Int16((t >> 12) & 0xFFF)
-        ok = ok and r.coeffs[2 * i] < Int16(Q) and r.coeffs[2 * i + 1] < Int16(Q)
+        ok = ok & (r.coeffs[2 * i] < Int16(Q)) & (r.coeffs[2 * i + 1] < Int16(Q))
     return ok
 
 
@@ -503,7 +503,7 @@ def polyvec_frombytes(mut r: Polyvec, a: Span[UInt8, ...], k: Int) raises -> Boo
         raise Error("ML-KEM polyvec_frombytes invalid buffer length")
     var ok = True
     for i in range(k):
-        ok = poly_frombytes(r.vec[i], a[i * POLYBYTES : (i + 1) * POLYBYTES]) and ok
+        ok = poly_frombytes(r.vec[i], a[i * POLYBYTES : (i + 1) * POLYBYTES]) & ok
     return ok
 
 
@@ -641,10 +641,9 @@ def poly_frommsg(mut r: Poly, msg: Span[UInt8, ...]) raises:
         raise Error("ML-KEM poly_frommsg invalid message length")
     for i in range(N // 8):
         for j in range(8):
-            var bit = (msg[i] >> UInt8(j)) & 1
-            r.coeffs[8 * i + j] = Int16(0)
-            if bit != 0:
-                r.coeffs[8 * i + j] = Int16((Q + 1) // 2)
+            # message bits are secret during decaps, don't branch on them
+            var mask = Int16(0) - Int16((msg[i] >> UInt8(j)) & 1)
+            r.coeffs[8 * i + j] = mask & Int16((Q + 1) // 2)
 
 
 def poly_tomsg(mut msg: List[UInt8], a: Poly):

--- a/src/thistle/ml_kem.mojo
+++ b/src/thistle/ml_kem.mojo
@@ -1,9 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 ML-KEM primitives implementation in Mojo
-By Libalpm64, no attribution required.
 """
 
 from std.collections import List
@@ -1672,9 +1668,7 @@ def mlkem_keygen_seed(seed: Span[UInt8, ...], parameter_set: String) raises -> T
     return (ek^, dk^)
 
 
-# FIPS 203 external ML-KEM.KeyGen().
-# Generates fresh d || z inside the cryptographic module, then calls the
-# deterministic internal seed expansion used by KATs and test vectors.
+# FIPS 203 ML-KEM.KeyGen(): fresh d || z, then deterministic expansion.
 def mlkem_keygen(parameter_set: String) raises -> Tuple[List[UInt8], List[UInt8]]:
     var seed = random_bytes(2 * SYMBYTES)
     var result = mlkem_keygen_seed(Span[UInt8, ...](seed), parameter_set)
@@ -1733,10 +1727,7 @@ def mlkem1024_keygen() raises -> Tuple[List[UInt8], List[UInt8]]:
     return (ek^, dk^)
 
 
-# FIPS 203 external ML-KEM.Encaps().
-# Generates fresh m inside the cryptographic module, then calls the
-# deterministic/internal encapsulation used by KATs and test vectors.
-# Return order follows the external KEM API: (ciphertext, shared_secret, ok).
+# FIPS 203 ML-KEM.Encaps(): fresh m, returns (ciphertext, shared_secret, ok).
 def mlkem_encaps(ek_bytes: Span[UInt8, ...], parameter_set: String) raises -> Tuple[List[UInt8], List[UInt8], Bool]:
     var m = random_bytes(SYMBYTES)
     var result = mlkem_encaps_seed(ek_bytes, Span[UInt8, ...](m), parameter_set)

--- a/src/thistle/p256.mojo
+++ b/src/thistle/p256.mojo
@@ -1,9 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 NIST P-256 / secp256r1 implementation.
-By libalpm64, no attribution required.
 """
 
 comptime P256_SIZE = 32
@@ -490,7 +486,6 @@ def _select_u256(a: U256, b: U256, choice: UInt64) -> U256:
 def _select_jacobian(
     a: P256JacobianPoint, b: P256JacobianPoint, choice: UInt64
 ) -> P256JacobianPoint:
-    # infinity flag is not used on the constant-time path
     var infinity = a.infinity
     if choice != 0:
         infinity = b.infinity
@@ -540,7 +535,6 @@ def _select_jacobian_ct(
 
 @always_inline
 def _mul_small_mod(x: U256, c: UInt64) -> U256:
-    # c is a public formula constant, doubling chains are fine
     if c == 2:
         return _add_mod(x, x, _p())
     if c == 3:
@@ -559,7 +553,7 @@ def _mul_small_mod(x: U256, c: UInt64) -> U256:
 
 
 def _is_on_curve(point: P256Point) -> Bool:
-    # cofactor-1 short Weierstrass curves validation for pub keys
+    # SEC 1 public key validation
     if point.infinity:
         return False
     if _cmp(point.x, _p()) >= 0 or _cmp(point.y, _p()) >= 0:
@@ -573,7 +567,6 @@ def _is_on_curve(point: P256Point) -> Bool:
 
 
 def _jacobian_double_ct(p: P256JacobianPoint) -> P256JacobianPoint:
-    # EFD shortw/jacobian-3 doubling, a = -3; scalar-core infinity is Z == 0.
     var delta = _square_mod(p.z, _p())
     var gamma = _square_mod(p.y, _p())
     var beta = _mul_mod(p.x, gamma, _p())

--- a/src/thistle/p256.mojo
+++ b/src/thistle/p256.mojo
@@ -184,14 +184,9 @@ def _sub_raw(a: U256, b: U256) -> Tuple[U256, UInt64]:
     var out = U256()
     var borrow: UInt64 = 0
     comptime for i in range(8):
-        var ai = a.limbs[i]
-        var bi = b.limbs[i] + borrow
-        if ai >= bi:
-            out.limbs[i] = ai - bi
-            borrow = 0
-        else:
-            out.limbs[i] = (UInt64(1) << UInt64(32)) + ai - bi
-            borrow = 1
+        var d = (UInt64(1) << UInt64(32)) + a.limbs[i] - b.limbs[i] - borrow
+        out.limbs[i] = d & _MASK32
+        borrow = (d >> UInt64(32)) ^ UInt64(1)
     return out, borrow
 
 
@@ -209,21 +204,17 @@ def _add_raw(a: U256, b: U256) -> Tuple[U256, UInt64]:
 @always_inline
 def _add_mod(a: U256, b: U256, m: U256) -> U256:
     var sum, carry = _add_raw(a, b)
-    if carry != 0:
-        sum, _ = _add_raw(sum, _p_overflow_correction())
-    if _cmp(sum, m) >= 0:
-        var reduced, _ = _sub_raw(sum, m)
-        return reduced
-    return sum
+    var sum_folded, _ = _add_raw(sum, _p_overflow_correction())
+    sum = _select_u256(sum, sum_folded, carry)
+    var sum_minus_m, borrow = _sub_raw(sum, m)
+    return _select_u256(sum_minus_m, sum, borrow)
 
 
 @always_inline
 def _sub_mod(a: U256, b: U256, m: U256) -> U256:
     var diff, borrow = _sub_raw(a, b)
-    if borrow != 0:
-        var fixed, _ = _add_raw(diff, m)
-        return fixed
-    return diff
+    var diff_plus_m, _ = _add_raw(diff, m)
+    return _select_u256(diff, diff_plus_m, borrow)
 
 
 @always_inline
@@ -233,11 +224,126 @@ def _add_small_mod(a: U256, small: UInt64, m: U256) -> U256:
 
 
 @always_inline
+def _add_signed_limb(
+    acc: InlineArray[Int64, 9], i: Int, value: UInt64, multiplier: Int64
+) -> InlineArray[Int64, 9]:
+    var out = acc
+    out[i] += Int64(value) * multiplier
+    return out
+
+
+@always_inline
+def _normalize_signed_p256(acc_in: InlineArray[Int64, 9]) -> U256:
+    var acc = acc_in
+    comptime for _ in range(4):
+        comptime for i in range(8):
+            var carry = acc[i] >> 32
+            acc[i] -= carry << 32
+            acc[i + 1] += carry
+
+        # Fold overflow 2^256 ≡ 2^224 - 2^192 - 2^96 + 1 mod p256.
+        var hi = acc[8]
+        acc[8] = 0
+        acc[0] += hi
+        acc[3] -= hi
+        acc[6] -= hi
+        acc[7] += hi
+
+    var out = U256()
+    comptime for i in range(8):
+        var carry = acc[i] >> 32
+        acc[i] -= carry << 32
+        if i < 7:
+            acc[i + 1] += carry
+        out.limbs[i] = UInt64(acc[i])
+
+    var minus_p, borrow = _sub_raw(out, _p())
+    out = _select_u256(minus_p, out, borrow)
+    var minus_p2, borrow2 = _sub_raw(out, _p())
+    return _select_u256(minus_p2, out, borrow2)
+
+
+@always_inline
+def _reduce_p256(t: InlineArray[UInt64, 16]) -> U256:
+    # FIPS 186-4 D.2.3 P-256 Mersenne reduction:
+    # r = s1 + 2*s2 + 2*s3 + s4 + s5 - s6 - s7 - s8 - s9 mod p.
+    var acc = InlineArray[Int64, 9](fill=0)
+
+    # s1 = (c7, ..., c0)
+    comptime for i in range(8):
+        acc = _add_signed_limb(acc, i, t[i], 1)
+
+    # 2*s2 = 2 * (c15, c14, c13, c12, c11, 0, 0, 0)
+    acc = _add_signed_limb(acc, 3, t[11], 2)
+    acc = _add_signed_limb(acc, 4, t[12], 2)
+    acc = _add_signed_limb(acc, 5, t[13], 2)
+    acc = _add_signed_limb(acc, 6, t[14], 2)
+    acc = _add_signed_limb(acc, 7, t[15], 2)
+
+    # 2*s3 = 2 * (0, c15, c14, c13, c12, 0, 0, 0)
+    acc = _add_signed_limb(acc, 3, t[12], 2)
+    acc = _add_signed_limb(acc, 4, t[13], 2)
+    acc = _add_signed_limb(acc, 5, t[14], 2)
+    acc = _add_signed_limb(acc, 6, t[15], 2)
+
+    # s4 = (c15, c14, 0, 0, 0, c10, c9, c8)
+    acc = _add_signed_limb(acc, 0, t[8], 1)
+    acc = _add_signed_limb(acc, 1, t[9], 1)
+    acc = _add_signed_limb(acc, 2, t[10], 1)
+    acc = _add_signed_limb(acc, 6, t[14], 1)
+    acc = _add_signed_limb(acc, 7, t[15], 1)
+
+    # s5 = (c8, c13, c15, c14, c13, c11, c10, c9)
+    acc = _add_signed_limb(acc, 0, t[9], 1)
+    acc = _add_signed_limb(acc, 1, t[10], 1)
+    acc = _add_signed_limb(acc, 2, t[11], 1)
+    acc = _add_signed_limb(acc, 3, t[13], 1)
+    acc = _add_signed_limb(acc, 4, t[14], 1)
+    acc = _add_signed_limb(acc, 5, t[15], 1)
+    acc = _add_signed_limb(acc, 6, t[13], 1)
+    acc = _add_signed_limb(acc, 7, t[8], 1)
+
+    # s6 = (c10, c8, 0, 0, 0, c13, c12, c11)
+    acc = _add_signed_limb(acc, 0, t[11], -1)
+    acc = _add_signed_limb(acc, 1, t[12], -1)
+    acc = _add_signed_limb(acc, 2, t[13], -1)
+    acc = _add_signed_limb(acc, 6, t[8], -1)
+    acc = _add_signed_limb(acc, 7, t[10], -1)
+
+    # s7 = (c11, c9, 0, 0, c15, c14, c13, c12)
+    acc = _add_signed_limb(acc, 0, t[12], -1)
+    acc = _add_signed_limb(acc, 1, t[13], -1)
+    acc = _add_signed_limb(acc, 2, t[14], -1)
+    acc = _add_signed_limb(acc, 3, t[15], -1)
+    acc = _add_signed_limb(acc, 6, t[9], -1)
+    acc = _add_signed_limb(acc, 7, t[11], -1)
+
+    # s8 = (c12, 0, c10, c9, c8, c15, c14, c13)
+    acc = _add_signed_limb(acc, 0, t[13], -1)
+    acc = _add_signed_limb(acc, 1, t[14], -1)
+    acc = _add_signed_limb(acc, 2, t[15], -1)
+    acc = _add_signed_limb(acc, 3, t[8], -1)
+    acc = _add_signed_limb(acc, 4, t[9], -1)
+    acc = _add_signed_limb(acc, 5, t[10], -1)
+    acc = _add_signed_limb(acc, 7, t[12], -1)
+
+    # s9 = (c13, 0, c11, c10, c9, 0, c15, c14)
+    acc = _add_signed_limb(acc, 0, t[14], -1)
+    acc = _add_signed_limb(acc, 1, t[15], -1)
+    acc = _add_signed_limb(acc, 3, t[9], -1)
+    acc = _add_signed_limb(acc, 4, t[10], -1)
+    acc = _add_signed_limb(acc, 5, t[11], -1)
+    acc = _add_signed_limb(acc, 7, t[13], -1)
+
+    return _normalize_signed_p256(acc)
+
+
+@always_inline
 def _mul_mod(a: U256, b: U256, m: U256) -> U256:
     var t = InlineArray[UInt64, 16](fill=0)
-    for i in range(8):
+    comptime for i in range(8):
         var carry = UInt128(0)
-        for j in range(8):
+        comptime for j in range(8):
             var k = i + j
             var prod = (
                 UInt128(a.limbs[i]) * UInt128(b.limbs[j])
@@ -252,15 +358,7 @@ def _mul_mod(a: U256, b: U256, m: U256) -> U256:
             t[k2] = UInt64(s & UInt128(_MASK32))
             carry = s >> UInt128(32)
             k2 += 1
-
-    var r = U256()
-    for bit_index in range(511, -1, -1):
-        r = _add_mod(r, r, m)
-        var limb = bit_index // 32
-        var bit = (t[limb] >> UInt64(bit_index % 32)) & 1
-        if bit != 0:
-            r = _add_small_mod(r, 1, m)
-    return r
+    return _reduce_p256(t)
 
 
 @always_inline
@@ -392,7 +490,7 @@ def _select_u256(a: U256, b: U256, choice: UInt64) -> U256:
 def _select_jacobian(
     a: P256JacobianPoint, b: P256JacobianPoint, choice: UInt64
 ) -> P256JacobianPoint:
-    # Coordinate path uses mask-select; infinity Bool is not on the CT scalar core.
+    # infinity flag is not used on the constant-time path
     var infinity = a.infinity
     if choice != 0:
         infinity = b.infinity
@@ -442,6 +540,18 @@ def _select_jacobian_ct(
 
 @always_inline
 def _mul_small_mod(x: U256, c: UInt64) -> U256:
+    # c is a public formula constant, doubling chains are fine
+    if c == 2:
+        return _add_mod(x, x, _p())
+    if c == 3:
+        return _add_mod(_add_mod(x, x, _p()), x, _p())
+    if c == 4:
+        var x2 = _add_mod(x, x, _p())
+        return _add_mod(x2, x2, _p())
+    if c == 8:
+        var x2 = _add_mod(x, x, _p())
+        var x4 = _add_mod(x2, x2, _p())
+        return _add_mod(x4, x4, _p())
     var out = U256()
     for _ in range(c):
         out = _add_mod(out, x, _p())
@@ -449,7 +559,7 @@ def _mul_small_mod(x: U256, c: UInt64) -> U256:
 
 
 def _is_on_curve(point: P256Point) -> Bool:
-    # SEC 1 public-key validation for cofactor-1 short Weierstrass curves.
+    # cofactor-1 short Weierstrass curves validation for pub keys
     if point.infinity:
         return False
     if _cmp(point.x, _p()) >= 0 or _cmp(point.y, _p()) >= 0:
@@ -488,7 +598,6 @@ def _jacobian_double_ct(p: P256JacobianPoint) -> P256JacobianPoint:
 def _jacobian_add_affine_ct(
     p: P256JacobianPoint, q: P256Point
 ) -> P256JacobianPoint:
-    # EFD mixed add; handle H == 0 by mask-selecting exceptional candidates.
     var z1z1 = _square_mod(p.z, _p())
     var u2 = _mul_mod(q.x, z1z1, _p())
     var s2 = _mul_mod(q.y, _mul_mod(p.z, z1z1, _p()), _p())
@@ -544,7 +653,6 @@ def _jacobian_to_affine(p: P256JacobianPoint) -> P256Point:
 
 
 def _scalar_mult(k: U256, p: P256Point) -> P256Point:
-    # Secret scalar loop: always double/add/select; scalar-core infinity is Z == 0.
     var acc = _jacobian_infinity()
     for j in range(256):
         var i = 255 - j
@@ -555,7 +663,7 @@ def _scalar_mult(k: U256, p: P256Point) -> P256Point:
 
 
 def p256_decode_uncompressed(point: Span[UInt8, ...]) -> P256Point:
-    # SEC 1 point decoding: compressed 02/03||X and uncompressed 04||X||Y.
+    # compressed 02/03||X and uncompressed 04||X||Y.
     if len(point) == 33 and (point[0] == 0x02 or point[0] == 0x03):
         var x = _from_be(
             Span[UInt8, ...](ptr=point.unsafe_ptr() + 1, length=32)
@@ -588,7 +696,7 @@ def p256_decode_uncompressed(point: Span[UInt8, ...]) -> P256Point:
 def p256_encode_uncompressed(
     point: P256Point, output: UnsafePointer[UInt8, MutAnyOrigin]
 ) -> Bool:
-    # SEC 1 uncompressed point encoding: 04 || X || Y.
+    # uncompressed point encoding: 04 || X || Y.
     if point.infinity or not _is_on_curve(point):
         return False
     output[0] = 0x04
@@ -597,10 +705,11 @@ def p256_encode_uncompressed(
     return True
 
 
+@no_inline
 def p256_public_key(
     private_key: Span[UInt8, ...], output: UnsafePointer[UInt8, MutAnyOrigin]
 ) -> Bool:
-    # SEC 1 key generation: Q = dG with d in [1, n - 1].
+    # Q = dG with d in [1, n - 1].
     if len(private_key) != 32:
         return False
     var d = _from_be(private_key)
@@ -610,12 +719,13 @@ def p256_public_key(
     return p256_encode_uncompressed(q, output)
 
 
+@no_inline
 def p256_ecdh(
     private_key: Span[UInt8, ...],
     public_key: Span[UInt8, ...],
     output: UnsafePointer[UInt8, MutAnyOrigin],
 ) -> Bool:
-    # SEC 1 ECDH: validate Q, compute dQ, reject infinity, output x-coordinate.
+    # validate Q, compute dQ, reject infinity, output x-coordinate.
     if len(private_key) != 32:
         return False
     var d = _from_be(private_key)

--- a/src/thistle/p384.mojo
+++ b/src/thistle/p384.mojo
@@ -226,14 +226,9 @@ def _sub_raw(a: U384, b: U384) -> Tuple[U384, UInt64]:
     var out = U384()
     var borrow: UInt64 = 0
     comptime for i in range(12):
-        var ai = a.limbs[i]
-        var bi = b.limbs[i] + borrow
-        if ai >= bi:
-            out.limbs[i] = ai - bi
-            borrow = 0
-        else:
-            out.limbs[i] = (UInt64(1) << UInt64(32)) + ai - bi
-            borrow = 1
+        var d = (UInt64(1) << UInt64(32)) + a.limbs[i] - b.limbs[i] - borrow
+        out.limbs[i] = d & _MASK32
+        borrow = (d >> UInt64(32)) ^ UInt64(1)
     return out, borrow
 
 
@@ -251,21 +246,17 @@ def _add_raw(a: U384, b: U384) -> Tuple[U384, UInt64]:
 @always_inline
 def _add_mod(a: U384, b: U384, m: U384) -> U384:
     var sum, carry = _add_raw(a, b)
-    if carry != 0:
-        sum, _ = _add_raw(sum, _p_overflow_correction())
-    if _cmp(sum, m) >= 0:
-        var reduced, _ = _sub_raw(sum, m)
-        return reduced
-    return sum
+    var sum_folded, _ = _add_raw(sum, _p_overflow_correction())
+    sum = _select_u384(sum, sum_folded, carry)
+    var sum_minus_m, borrow = _sub_raw(sum, m)
+    return _select_u384(sum_minus_m, sum, borrow)
 
 
 @always_inline
 def _sub_mod(a: U384, b: U384, m: U384) -> U384:
     var diff, borrow = _sub_raw(a, b)
-    if borrow != 0:
-        var fixed, _ = _add_raw(diff, m)
-        return fixed
-    return diff
+    var diff_plus_m, _ = _add_raw(diff, m)
+    return _select_u384(diff, diff_plus_m, borrow)
 
 
 @always_inline
@@ -308,11 +299,10 @@ def _normalize_signed_p384(acc_in: InlineArray[Int64, 13]) -> U384:
             acc[i + 1] += carry
         out.limbs[i] = UInt64(acc[i])
 
-    if _cmp(out, _p()) >= 0:
-        out, _ = _sub_raw(out, _p())
-    if _cmp(out, _p()) >= 0:
-        out, _ = _sub_raw(out, _p())
-    return out
+    var minus_p, borrow = _sub_raw(out, _p())
+    out = _select_u384(minus_p, out, borrow)
+    var minus_p2, borrow2 = _sub_raw(out, _p())
+    return _select_u384(minus_p2, out, borrow2)
 
 
 @always_inline
@@ -520,7 +510,7 @@ def _select_u384(a: U384, b: U384, choice: UInt64) -> U384:
 def _select_jacobian(
     a: P384JacobianPoint, b: P384JacobianPoint, choice: UInt64
 ) -> P384JacobianPoint:
-    # Coordinate path uses mask-select; infinity Bool is not on the CT scalar core.
+    # infinity flag is not used on the constant-time path
     var infinity = a.infinity
     if choice != 0:
         infinity = b.infinity
@@ -570,6 +560,17 @@ def _select_jacobian_ct(
 
 @always_inline
 def _mul_small_mod(x: U384, c: UInt64) -> U384:
+    if c == 2:
+        return _add_mod(x, x, _p())
+    if c == 3:
+        return _add_mod(_add_mod(x, x, _p()), x, _p())
+    if c == 4:
+        var x2 = _add_mod(x, x, _p())
+        return _add_mod(x2, x2, _p())
+    if c == 8:
+        var x2 = _add_mod(x, x, _p())
+        var x4 = _add_mod(x2, x2, _p())
+        return _add_mod(x4, x4, _p())
     var out = U384()
     for _ in range(c):
         out = _add_mod(out, x, _p())
@@ -725,6 +726,7 @@ def p384_encode_uncompressed(
     return True
 
 
+@no_inline
 def p384_public_key(
     private_key: Span[UInt8, ...], output: UnsafePointer[UInt8, MutAnyOrigin]
 ) -> Bool:
@@ -738,6 +740,7 @@ def p384_public_key(
     return p384_encode_uncompressed(q, output)
 
 
+@no_inline
 def p384_ecdh(
     private_key: Span[UInt8, ...],
     public_key: Span[UInt8, ...],

--- a/src/thistle/p384.mojo
+++ b/src/thistle/p384.mojo
@@ -1,9 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 NIST P-384 / secp384r1 implementation.
-By libalpm64, no attribution required.
 """
 
 comptime P384_SIZE = 48

--- a/src/thistle/pbkdf2.mojo
+++ b/src/thistle/pbkdf2.mojo
@@ -1,10 +1,6 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 PBKDF2 (Password-Based Key Derivation Function 2) Implementation in Mojo
 SP 800-132 / FIPS 140-2 / RFC 8018
-By Libalpm64, Attribute not required.
 """
 from std.collections import List
 from std.memory import memset_zero, memcpy, UnsafePointer

--- a/src/thistle/pbkdf2.mojo
+++ b/src/thistle/pbkdf2.mojo
@@ -126,7 +126,11 @@ struct PBKDF2SHA256(Movable):
 
 def pbkdf2_hmac_sha256(
     password: Span[UInt8, ...], salt: Span[UInt8, ...], iterations: Int, dkLen: Int
-) -> List[UInt8]:
+) raises -> List[UInt8]:
+    if iterations < 1:
+        raise Error("PBKDF2 iterations must be at least 1")
+    if dkLen < 1:
+        raise Error("PBKDF2 dkLen must be at least 1")
     var ctx = PBKDF2SHA256(password)
     return ctx.derive(salt, iterations, dkLen)
 
@@ -224,7 +228,11 @@ struct PBKDF2SHA512(Movable):
 
 def pbkdf2_hmac_sha512(
     password: Span[UInt8, ...], salt: Span[UInt8, ...], iterations: Int, dkLen: Int
-) -> List[UInt8]:
+) raises -> List[UInt8]:
+    if iterations < 1:
+        raise Error("PBKDF2 iterations must be at least 1")
+    if dkLen < 1:
+        raise Error("PBKDF2 dkLen must be at least 1")
     var ctx = PBKDF2SHA512(password)
     return ctx.derive(salt, iterations, dkLen)
 

--- a/src/thistle/random.mojo
+++ b/src/thistle/random.mojo
@@ -20,8 +20,7 @@ def _getrandom_linux_x86(buf: UnsafePointer[UInt8, MutAnyOrigin], length: Int) -
 @always_inline
 def _getrandom_linux_arm(buf: UnsafePointer[UInt8, MutAnyOrigin], length: Int) -> Int:
     # Linux aarch64: getrandom(buf, len, flags=0), syscall 278.
-    # Put inputs in scratch registers first, then move them into the syscall ABI
-    # registers inside the asm block. This avoids fixed input/output conflicts.
+    # inputs go via scratch registers to avoid asm constraint conflicts
     return Int(
         inlined_assembly[
             """

--- a/src/thistle/sha2.mojo
+++ b/src/thistle/sha2.mojo
@@ -1,10 +1,6 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 SHA-2 (SHA-256/SHA-512) Implementation in Mojo
 RFC 6234 / FIPS 180-4 / CAVP validated
-By Libalpm64, Attribute not required.
 """
 
 from std.collections import List
@@ -179,7 +175,6 @@ def small_sigma1_generic[WordType: DType](x: SIMD[WordType, 1]) -> SIMD[WordType
         return SIMD[WordType, 1](rotate_bits_right[19](x[0]) ^ rotate_bits_right[61](x[0]) ^ (x[0] >> 6))
 
 
-# hex conversions
 @always_inline
 def nibble_to_hex_char(nibble: UInt8) -> UInt8:
     """Convert a nibble (0-15) to its hex character ASCII value."""

--- a/src/thistle/sha2.mojo
+++ b/src/thistle/sha2.mojo
@@ -503,6 +503,17 @@ struct SHA512Context(Movable):
     def __del__(deinit self):
         memset_zero(self.buffer.unsafe_ptr(), 128)
 
+    def wipe(mut self):
+        UnsafePointer(to=self.state).bitcast[UInt64]().store[volatile=True](
+            0, SIMD[DType.uint64, 8](0)
+        )
+        var buf_ptr = self.buffer.unsafe_ptr()
+        for i in range(128):
+            buf_ptr.store[volatile=True](i, UInt8(0))
+        self.count_high = 0
+        self.count_low = 0
+        self.buffer_len = 0
+
     def reset(mut self):
         var iv = SHA512_IV
         self.state = iv

--- a/src/thistle/sha3.mojo
+++ b/src/thistle/sha3.mojo
@@ -1,10 +1,6 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 SHA-3 (Keccak) + shake128/shake256 Implementation in Mojo
 FIPS 202
-By Libalpm64, Attribute not required.
 """
 
 from std.collections import List

--- a/src/thistle/sha_ni.mojo
+++ b/src/thistle/sha_ni.mojo
@@ -43,7 +43,12 @@ comptime SHA256_K = SIMD[DType.uint32, 64](
 
 @always_inline
 def has_x86_sha_ni() -> Bool:
-    return CompilationTarget._has_feature["sse"]() and CompilationTarget._has_feature["sha"]()
+    return CompilationTarget.is_x86() and CompilationTarget._has_feature["sse"]() and CompilationTarget._has_feature["sha"]()
+
+
+@always_inline
+def has_arm_sha2() -> Bool:
+    return CompilationTarget.has_neon() and CompilationTarget._has_feature["sha2"]() and not CompilationTarget.is_x86()
 
 
 @always_inline("nodebug")
@@ -71,6 +76,38 @@ def _msg2(a: SIMD128, b: SIMD128) -> SIMD128:
 
 
 @always_inline("nodebug")
+def _arm_sha256h(abcd: SIMD128, efgh: SIMD128, wk: SIMD128) -> SIMD128:
+    comptime if CompilationTarget.has_neon() and CompilationTarget._has_feature["sha2"]() and not CompilationTarget.is_x86():
+        return llvm_intrinsic["llvm.aarch64.crypto.sha256h", SIMD128, has_side_effect=False](abcd, efgh, wk)
+    else:
+        return SIMD128(0)
+
+
+@always_inline("nodebug")
+def _arm_sha256h2(efgh: SIMD128, abcd: SIMD128, wk: SIMD128) -> SIMD128:
+    comptime if CompilationTarget.has_neon() and CompilationTarget._has_feature["sha2"]() and not CompilationTarget.is_x86():
+        return llvm_intrinsic["llvm.aarch64.crypto.sha256h2", SIMD128, has_side_effect=False](efgh, abcd, wk)
+    else:
+        return SIMD128(0)
+
+
+@always_inline("nodebug")
+def _arm_sha256su0(w0_3: SIMD128, w4_7: SIMD128) -> SIMD128:
+    comptime if CompilationTarget.has_neon() and CompilationTarget._has_feature["sha2"]() and not CompilationTarget.is_x86():
+        return llvm_intrinsic["llvm.aarch64.crypto.sha256su0", SIMD128, has_side_effect=False](w0_3, w4_7)
+    else:
+        return SIMD128(0)
+
+
+@always_inline("nodebug")
+def _arm_sha256su1(tw0_3: SIMD128, w8_11: SIMD128, w12_15: SIMD128) -> SIMD128:
+    comptime if CompilationTarget.has_neon() and CompilationTarget._has_feature["sha2"]() and not CompilationTarget.is_x86():
+        return llvm_intrinsic["llvm.aarch64.crypto.sha256su1", SIMD128, has_side_effect=False](tw0_3, w8_11, w12_15)
+    else:
+        return SIMD128(0)
+
+
+@always_inline("nodebug")
 def byte_swap32(v: SIMD128) -> SIMD128:
     var bytes = bitcast[DType.uint8, 16](v)
     var swapped = bytes.shuffle[3,2,1,0, 7,6,5,4, 11,10,9,8, 15,14,13,12]()
@@ -93,16 +130,58 @@ def prefetch_next_block(ptr: UnsafePointer[UInt8, ImmutAnyOrigin]):
 
 
 def sha256ni_transform(state: SIMD[DType.uint32, 8], block: Span[UInt8, ...]) -> SIMD[DType.uint32, 8]:
+    comptime if CompilationTarget.is_x86():
+        return _sha256ni_transform_x86(state, block)
+    else:
+        return _sha256ni_transform_arm(state, block)
+
+
+def _sha256ni_transform_arm(state: SIMD[DType.uint32, 8], block: Span[UInt8, ...]) -> SIMD[DType.uint32, 8]:
     var ptr = block.unsafe_ptr()
-    
-    # states:  s1 = [H, G, D, C], s0 = [F, E, B, A]
+
+    # st0 = [A, B, C, D], st1 = [E, F, G, H].
+    var st0 = SIMD128(state[0], state[1], state[2], state[3])
+    var st1 = SIMD128(state[4], state[5], state[6], state[7])
+    var old_st0 = st0
+    var old_st1 = st1
+
+    var w = InlineArray[SIMD128, 4](uninitialized=True)
+    w[0] = Load(ptr)
+    w[1] = Load(ptr + 16)
+    w[2] = Load(ptr + 32)
+    w[3] = Load(ptr + 48)
+
+    comptime for i in range(16):
+        var wk = w[i & 3] + SIMD128(SHA256_K[4 * i], SHA256_K[4 * i + 1], SHA256_K[4 * i + 2], SHA256_K[4 * i + 3])
+        comptime if i < 12:
+            w[i & 3] = _arm_sha256su1(
+                _arm_sha256su0(w[i & 3], w[(i + 1) & 3]),
+                w[(i + 2) & 3],
+                w[(i + 3) & 3],
+            )
+        var tmp = st0
+        st0 = _arm_sha256h(st0, st1, wk)
+        st1 = _arm_sha256h2(st1, tmp, wk)
+
+    st0 += old_st0
+    st1 += old_st1
+
+    return SIMD[DType.uint32, 8](
+        st0[0], st0[1], st0[2], st0[3], st1[0], st1[1], st1[2], st1[3]
+    )
+
+
+def _sha256ni_transform_x86(state: SIMD[DType.uint32, 8], block: Span[UInt8, ...]) -> SIMD[DType.uint32, 8]:
+    var ptr = block.unsafe_ptr()
+
+    # s1 = [H, G, D, C], s0 = [F, E, B, A]
     var s1 = SIMD128(state[7], state[6], state[3], state[2])
     var s0 = SIMD128(state[5], state[4], state[1], state[0])
     
     var old_s0 = s0
     var old_s1 = s1
     
-    # expand all 64 words (16 SIMD registers)
+    # expand all 64 words to 16 simd registers
     var w0 = Load(ptr)
     var w1 = Load(ptr + 16)
     var w2 = Load(ptr + 32)
@@ -193,4 +272,4 @@ def sha256ni_hash(data: Span[UInt8, ...]) -> List[UInt8]:
     return output^
 
 def has_sha_ni() -> Bool:
-    return has_x86_sha_ni()
+    return has_x86_sha_ni() or has_arm_sha2()

--- a/src/thistle/sha_ni.mojo
+++ b/src/thistle/sha_ni.mojo
@@ -1,9 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 SHA-NI implementation In Mojo.
-By Libalpm64, attribution not required.
 """
 
 from std.sys import llvm_intrinsic, CompilationTarget, prefetch, PrefetchOptions
@@ -11,7 +7,7 @@ from std.memory import UnsafePointer, bitcast
 from .utils import StackBuffer
 from std.builtin.simd import SIMD
 from std.builtin.dtype import DType
-from .sha2 import SHA256_IV
+from .sha2 import SHA256_IV, sha256_transform
 
 comptime SIMD128 = SIMD[DType.uint32, 4]
 comptime PAL_0 = 1
@@ -130,10 +126,13 @@ def prefetch_next_block(ptr: UnsafePointer[UInt8, ImmutAnyOrigin]):
 
 
 def sha256ni_transform(state: SIMD[DType.uint32, 8], block: Span[UInt8, ...]) -> SIMD[DType.uint32, 8]:
-    comptime if CompilationTarget.is_x86():
+    # fall back to the scalar transform so unsupported CPUs never get zeros
+    comptime if CompilationTarget.is_x86() and CompilationTarget._has_feature["sse"]() and CompilationTarget._has_feature["sha"]():
         return _sha256ni_transform_x86(state, block)
-    else:
+    elif CompilationTarget.has_neon() and CompilationTarget._has_feature["sha2"]() and not CompilationTarget.is_x86():
         return _sha256ni_transform_arm(state, block)
+    else:
+        return sha256_transform(state, block)
 
 
 def _sha256ni_transform_arm(state: SIMD[DType.uint32, 8], block: Span[UInt8, ...]) -> SIMD[DType.uint32, 8]:

--- a/src/thistle/utils.mojo
+++ b/src/thistle/utils.mojo
@@ -1,13 +1,11 @@
-from std.builtin.rebind import downcast
-from std.builtin.constrained import _constrained_conforms_to
-from std.memory import stack_allocation
-
 struct StackInlineArray[ElementType: Copyable, size: Int](Copyable):
-    var _ptr: UnsafePointer[Self.ElementType, MutExternalOrigin]
+    var _data: InlineArray[Self.ElementType, Self.size]
 
     @always_inline
     def __init__(out self, *, uninitialized: Bool):
-        self._ptr = stack_allocation[Self.size, Self.ElementType]()
+        self._data = InlineArray[Self.ElementType, Self.size](
+            uninitialized=True
+        )
 
     @always_inline
     def __init__(out self, var *elems: Self.ElementType, __list_literal__: NoneType):
@@ -54,14 +52,14 @@ struct StackInlineArray[ElementType: Copyable, size: Int](Copyable):
         address_space=address_space
     ]:
         return (
-            self._ptr
+            self._data.unsafe_ptr()
             .unsafe_mut_cast[origin.mut]()
             .unsafe_origin_cast[origin]()
             .address_space_cast[address_space]()
         )
 
     @always_inline
-    def unsafe_get[I: Indexer](ref self, idx: I) -> ref[MutExternalOrigin] Self.ElementType:
+    def unsafe_get[I: Indexer](ref self, idx: I) -> ref[self._data] Self.ElementType:
         var i = index(idx)
         debug_assert(
             0 <= i < Self.size,
@@ -70,12 +68,12 @@ struct StackInlineArray[ElementType: Copyable, size: Int](Copyable):
             " should be greater than or equal to 0 and less than ",
             Self.size,
         )
-        return self._ptr[i]
+        return self._data.unsafe_get(i)
 
     @always_inline
     def __getitem_param__[
         idx: Some[Indexer]
-    ](ref self) -> ref[MutExternalOrigin] Self.ElementType:
+    ](ref self) -> ref[self._data] Self.ElementType:
         comptime i = index(idx)
         comptime assert 0 <= i < Self.size, "Index must be within bounds."
         return self.unsafe_get(i)
@@ -83,13 +81,13 @@ struct StackInlineArray[ElementType: Copyable, size: Int](Copyable):
     @always_inline
     def __getitem_param__[
         idx: Int
-    ](ref self) -> ref[MutExternalOrigin] Self.ElementType:
+    ](ref self) -> ref[self._data] Self.ElementType:
         comptime i = index(idx)
         comptime assert 0 <= i < Self.size, "Index must be within bounds."
         return self.unsafe_get(i)
 
     @always_inline
-    def __getitem__(ref self, idx: Int) -> ref[MutExternalOrigin] Self.ElementType:
+    def __getitem__(ref self, idx: Int) -> ref[self._data] Self.ElementType:
         debug_assert(
             0 <= idx < Self.size,
             "Index out of bounds: ", idx, " should be in [0, ", Self.size, ")",
@@ -104,24 +102,8 @@ struct StackInlineArray[ElementType: Copyable, size: Int](Copyable):
             0 <= idx < Self.size,
             "The index provided must be within the range [0, len(List) -1] when using List.unsafe_set()",
         )
-        (self._ptr + idx).destroy_pointee()
-        (self._ptr + idx).init_pointee_move(value^)
-
-    def __del__(deinit self):
-        _constrained_conforms_to[
-            conforms_to(Self.ElementType, ImplicitlyDestructible),
-            Parent=Self,
-            Element = Self.ElementType,
-            ParentConformsTo="ImplicitlyDestructible",
-        ]()
-        comptime TDestructible = downcast[
-            Self.ElementType, ImplicitlyDestructible
-        ]
-
-        comptime if not TDestructible.__del__is_trivial:
-            comptime for idx in range(Self.size):
-                var ptr = self.unsafe_ptr() + idx
-                ptr.bitcast[TDestructible]().destroy_pointee()
+        (self._data.unsafe_ptr() + idx).destroy_pointee()
+        (self._data.unsafe_ptr() + idx).init_pointee_move(value^)
 
 
 struct StackBuffer[T: Copyable & ImplicitlyDestructible, N: Int](Movable):

--- a/src/thistle/x25519.mojo
+++ b/src/thistle/x25519.mojo
@@ -1,9 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 X25519 implementation
-By Libalpm64
 """
 
 from .curve25519 import FieldElement51
@@ -43,10 +39,7 @@ def x25519(scalar_in: Span[UInt8, ...], point: Span[UInt8, ...], output: UnsafeP
     scalar[31] |= 64
 
     var u = FieldElement51.from_bytes_span(point)
-    # RFC 7748 Section 5: X25519 masks the most significant bit of the
-    # received u-coordinate. FieldElement51.from_bytes_span already masks this
-    # bit through the 51-bit top limb mask; keep it explicit here at the X25519
-    # boundary so the protocol rule is not hidden inside field decoding.
+    # RFC 7748: mask the top bit of the u-coordinate (kept explicit here)
     u.limbs[4] &= (UInt64(1) << UInt64(51)) - UInt64(1)
 
     var x_1 = u

--- a/src/thistle/x25519.mojo
+++ b/src/thistle/x25519.mojo
@@ -29,7 +29,12 @@ def _cswap_pair(
     _cswap_fe(swap, x_2, x_3)
     _cswap_fe(swap, z_2, z_3)
 
-def x25519(scalar_in: Span[UInt8, ...], point: Span[UInt8, ...], output: UnsafePointer[UInt8, MutAnyOrigin]):
+@no_inline
+def x25519(scalar_in: Span[UInt8, ...], point: Span[UInt8, ...], output: UnsafePointer[UInt8, MutAnyOrigin]) raises:
+    if len(scalar_in) < 32:
+        raise Error("X25519 scalar must be 32 bytes")
+    if len(point) < 32:
+        raise Error("X25519 point must be 32 bytes")
     var scalar = StackInlineArray[UInt8, 32](uninitialized=True)
     for i in range(32):
         scalar[i] = scalar_in[i]
@@ -76,3 +81,6 @@ def x25519(scalar_in: Span[UInt8, ...], point: Span[UInt8, ...], output: UnsafeP
         
     var res = x_2 * z_2.invert()
     res.to_bytes_into(output)
+    var scalar_ptr = scalar.unsafe_ptr()
+    for i in range(32):
+        scalar_ptr.store[volatile=True](i, UInt8(0))

--- a/tests/benchmark.mojo
+++ b/tests/benchmark.mojo
@@ -15,6 +15,9 @@ from thistle.sha2 import sha256_hash, sha512_hash
 from thistle.sha_ni import sha256ni_hash, has_sha_ni
 from thistle.sha3 import sha3_256
 from thistle.aes import AESKey, SBOX, cpu_aes_encrypt, ROUNDS_128, expand_key_128
+from thistle.x25519 import x25519
+from thistle.ed25519 import ed25519_sign, ed25519_verify, ed25519_generate_public_key
+from thistle.utils import StackInlineArray
 from std.memory import alloc
 from std.utils import StaticTuple
 
@@ -33,6 +36,69 @@ def generate_data(length: Int) -> List[UInt8]:
     for i in range(length):
         data.append(UInt8(i % 256))
     return data^
+
+
+def benchmark_x25519(duration_secs: Float64) raises -> String:
+    var scalar = InlineArray[UInt8, 32](uninitialized=True)
+    var point = InlineArray[UInt8, 32](uninitialized=True)
+    var out = InlineArray[UInt8, 32](uninitialized=True)
+    for i in range(32):
+        scalar[i] = UInt8(i + 1)
+        point[i] = UInt8(9) if i == 0 else UInt8(0)
+    var scalar_span = Span[UInt8, ...](ptr=scalar.unsafe_ptr(), length=32)
+    var point_span = Span[UInt8, ...](ptr=point.unsafe_ptr(), length=32)
+    x25519(scalar_span, point_span, out.unsafe_ptr())
+    var count = 0
+    var start = perf_counter()
+    while perf_counter() - start < duration_secs:
+        x25519(scalar_span, point_span, out.unsafe_ptr())
+        scalar.unsafe_ptr().store[volatile=True](0, out[0] | 8)
+        count += 1
+    var duration = perf_counter() - start
+    var ops = Float64(count) / duration
+    return "x25519 | throughput: " + String(ops)[byte=:8] + " ops/s, ops: " + String(count) + ", time: " + String(duration)[byte=:4] + "s"
+
+
+def benchmark_ed25519(duration_secs: Float64) raises -> String:
+    var sk = InlineArray[UInt8, 32](uninitialized=True)
+    var pk = InlineArray[UInt8, 32](uninitialized=True)
+    var msg = InlineArray[UInt8, 64](uninitialized=True)
+    var sig = InlineArray[UInt8, 64](uninitialized=True)
+    for i in range(32):
+        sk[i] = UInt8(i * 7 + 1)
+    for i in range(64):
+        msg[i] = UInt8(i)
+    var sk_span = Span[UInt8, ...](ptr=sk.unsafe_ptr(), length=32)
+    var msg_span = Span[UInt8, ...](ptr=msg.unsafe_ptr(), length=64)
+    var sig_span = Span[UInt8, ...](ptr=sig.unsafe_ptr(), length=64)
+    var pk_span = Span[UInt8, ...](ptr=pk.unsafe_ptr(), length=32)
+    ed25519_generate_public_key(sk_span, pk.unsafe_ptr())
+    ed25519_sign(sk_span, msg_span, sig.unsafe_ptr())
+
+    var sign_count = 0
+    var start = perf_counter()
+    while perf_counter() - start < duration_secs:
+        ed25519_sign(sk_span, msg_span, sig.unsafe_ptr())
+        sign_count += 1
+    var sign_duration = perf_counter() - start
+    var sign_ops = Float64(sign_count) / sign_duration
+
+    ed25519_sign(sk_span, msg_span, sig.unsafe_ptr())
+    var verify_count = 0
+    var verify_failures = 0
+    start = perf_counter()
+    while perf_counter() - start < duration_secs:
+        if not ed25519_verify(pk_span, msg_span, sig_span):
+            verify_failures += 1
+        verify_count += 1
+    var verify_duration = perf_counter() - start
+    var verify_ops = Float64(verify_count) / verify_duration
+
+    var result = "ed25519-sign | throughput: " + String(sign_ops)[byte=:8] + " ops/s, ops: " + String(sign_count) + ", time: " + String(sign_duration)[byte=:4] + "s\n"
+    result += "ed25519-verify | throughput: " + String(verify_ops)[byte=:8] + " ops/s, ops: " + String(verify_count) + ", time: " + String(verify_duration)[byte=:4] + "s"
+    if verify_failures > 0:
+        result += " [" + String(verify_failures) + " FAILED VERIFICATIONS]"
+    return result
 
 
 def benchmark_sha256(data: List[UInt8], duration_secs: Float64) -> String:
@@ -128,7 +194,7 @@ def benchmark_blake3(data: List[UInt8], duration_secs: Float64) -> String:
     return "blake3 | throughput: " + String(mbps)[byte=:6] + " mb/s, hashes: " + String(count) + ", time: " + String(duration)[byte=:4] + "s"
 
 
-def benchmark_camellia(data_size: Int, duration_secs: Float64) -> String:
+def benchmark_camellia(data_size: Int, duration_secs: Float64) raises -> String:
     var key = List[UInt8]()
     for i in range(16):
         key.append(UInt8(i))
@@ -153,7 +219,7 @@ def benchmark_camellia(data_size: Int, duration_secs: Float64) -> String:
     return "camellia | throughput: " + String(mbps)[byte=:6] + " mb/s, blocks: " + String(count) + ", time: " + String(duration)[byte=:4] + "s"
 
 
-def benchmark_chacha20(data_size: Int, duration_secs: Float64) -> String:
+def benchmark_chacha20(data_size: Int, duration_secs: Float64) raises -> String:
     var key = SIMD[DType.uint8, 32](0)
     for i in range(32):
         key[i] = UInt8(i)
@@ -204,7 +270,7 @@ def benchmark_kcipher2(data_size: Int, duration_secs: Float64) -> String:
     return "kcipher2 | throughput: " + String(mbps)[byte=:6] + " mb/s, encrypts: " + String(count) + ", time: " + String(duration)[byte=:4] + "s"
 
 
-def benchmark_argon2(duration_secs: Float64) -> String:
+def benchmark_argon2(duration_secs: Float64) raises -> String:
     var password = String("password").as_bytes()
     var salt = String("saltsalt12345678").as_bytes()
     var ctx = Argon2id(salt, memory_size_kb=65536, iterations=3, parallelism=4)
@@ -443,6 +509,8 @@ def main() raises:
     print(benchmark_aes_gpu_ecb())
     print(benchmark_aes_gpu_ctr())
     print(benchmark_argon2(duration))
-    
+    print(benchmark_x25519(duration))
+    print(benchmark_ed25519(duration))
+
     print()
     print("All benchmarks completed")

--- a/tests/benchmark.mojo
+++ b/tests/benchmark.mojo
@@ -288,7 +288,7 @@ def benchmark_aes_gpu_ecb() raises -> String:
         var block_dim = 256
         var grid_dim = ceildiv(num_blocks, block_dim)
         
-        ctx.enqueue_function[aes_gpu_kernel_ecb, aes_gpu_kernel_ecb](
+        ctx.enqueue_function[aes_gpu_kernel_ecb](
             input_buffer.unsafe_ptr(),
             output_buffer.unsafe_ptr(),
             round_keys_buffer.unsafe_ptr(),
@@ -303,7 +303,7 @@ def benchmark_aes_gpu_ecb() raises -> String:
         var iterations = 50
         var start = perf_counter()
         for _ in range(iterations):
-            ctx.enqueue_function[aes_gpu_kernel_ecb, aes_gpu_kernel_ecb](
+            ctx.enqueue_function[aes_gpu_kernel_ecb](
                 input_buffer.unsafe_ptr(),
                 output_buffer.unsafe_ptr(),
                 round_keys_buffer.unsafe_ptr(),
@@ -373,7 +373,7 @@ def benchmark_aes_gpu_ctr() raises -> String:
         var block_dim = 256
         var grid_dim = ceildiv(num_blocks, block_dim)
         
-        ctx.enqueue_function[aes_gpu_kernel_ctr, aes_gpu_kernel_ctr](
+        ctx.enqueue_function[aes_gpu_kernel_ctr](
             input_buffer.unsafe_ptr(),
             output_buffer.unsafe_ptr(),
             round_keys_buffer.unsafe_ptr(),
@@ -389,7 +389,7 @@ def benchmark_aes_gpu_ctr() raises -> String:
         var iterations = 50
         var start = perf_counter()
         for _ in range(iterations):
-            ctx.enqueue_function[aes_gpu_kernel_ctr, aes_gpu_kernel_ctr](
+            ctx.enqueue_function[aes_gpu_kernel_ctr](
                 input_buffer.unsafe_ptr(),
                 output_buffer.unsafe_ptr(),
                 round_keys_buffer.unsafe_ptr(),
@@ -415,6 +415,9 @@ def benchmark_aes_gpu_ctr() raises -> String:
         key_ptr.free()
         
         return "aes-128-gpu-ctr | throughput: " + String(gbps)[byte=:6] + " gb/s, iterations: " + String(iterations)
+
+
+
 
 
 def main() raises:

--- a/tests/test_aes_gpu.mojo
+++ b/tests/test_aes_gpu.mojo
@@ -4,7 +4,7 @@ from std.collections import List
 from std.sys import has_accelerator
 from thistle.sha2 import bytes_to_hex
 from thistle.aes import SBOX, expand_key_128, expand_key_192, expand_key_256
-from thistle.aes_gpu import aes_gpu_kernel_ecb, aes_gpu_kernel_ctr, aes_gpu_kernel_gcm, aes_gpu_kernel_xts
+from thistle.aes_gpu import aes_gpu_kernel_ecb, aes_gpu_kernel_ctr, aes_gpu_kernel_gcm
 from std.memory import alloc
 from std.gpu.host import DeviceContext
 from std.memory.unsafe_pointer import UnsafePointer
@@ -192,14 +192,7 @@ def test_mode_gpu(json_data: PythonObject, mode: String) raises -> TestResult:
         var round_keys_size: Int
         var round_keys: UnsafePointer[UInt32, MutAnyOrigin]
         
-        if "XTS" in mode:
-            key_ptr = alloc[UInt8](32)
-            for j in range(min(key_len, 32)):
-                key_ptr.store(j, key_bytes[j])
-            round_keys_size = 44
-            round_keys = expand_key_128(key_ptr)
-        else:
-            if key_len == 16:
+        if key_len == 16:
                 key_ptr = alloc[UInt8](16)
                 for j in range(16):
                     key_ptr.store(j, key_bytes[j])
@@ -304,66 +297,6 @@ def test_mode_gpu(json_data: PythonObject, mode: String) raises -> TestResult:
                 grid_dim=grid_dim,
                 block_dim=block_dim,
             )
-        elif "XTS" in mode:
-            var tweak_hex = String(tv.get("tweak", PythonObject()))
-            var tweak_ptr = alloc[UInt8](16)
-            if tweak_hex.byte_length() == 0:
-                for j in range(16):
-                    tweak_ptr[j] = 0
-            else:
-                var tweak_bytes = hex_to_bytes(tweak_hex)
-                for j in range(16):
-                    tweak_ptr.store(j, tweak_bytes[j])
-            
-            var key1_ptr: UnsafePointer[UInt8, MutAnyOrigin]
-            var key2_ptr: UnsafePointer[UInt8, MutAnyOrigin]
-            var xts_rounds: Int
-            
-            if key_len == 32:
-                key1_ptr = alloc[UInt8](16)
-                key2_ptr = alloc[UInt8](16)
-                for j in range(16):
-                    key1_ptr.store(j, key_bytes[j])
-                    key2_ptr.store(j, key_bytes[j + 16])
-                xts_rounds = 10
-            else:
-                key1_ptr = alloc[UInt8](32)
-                key2_ptr = alloc[UInt8](32)
-                for j in range(32):
-                    key1_ptr.store(j, key_bytes[j])
-                    key2_ptr.store(j, key_bytes[j + 32])
-                xts_rounds = 14
-            
-            var round_keys1 = expand_key_128(key1_ptr) if xts_rounds == 10 else expand_key_256(key1_ptr)
-            var round_keys2 = expand_key_128(key2_ptr) if xts_rounds == 10 else expand_key_256(key2_ptr)
-            
-            var round_keys1_size = 44 if xts_rounds == 10 else 60
-            var round_keys2_size = 44 if xts_rounds == 10 else 60
-            var round_keys1_buffer = ctx.enqueue_create_buffer[DType.uint32](round_keys1_size)
-            var round_keys2_buffer = ctx.enqueue_create_buffer[DType.uint32](round_keys2_size)
-            ctx.enqueue_copy(round_keys1_buffer, round_keys1)
-            ctx.enqueue_copy(round_keys2_buffer, round_keys2)
-            
-            var tweak_buffer = ctx.enqueue_create_buffer[DType.uint8](16)
-            ctx.enqueue_copy(tweak_buffer, tweak_ptr)
-            ctx.synchronize()
-            
-            ctx.enqueue_function[aes_gpu_kernel_xts](
-                input_buffer.unsafe_ptr(),
-                output_buffer.unsafe_ptr(),
-                round_keys1_buffer.unsafe_ptr(),
-                round_keys2_buffer.unsafe_ptr(),
-                sbox_buffer.unsafe_ptr(),
-                n_blocks,
-                tweak_buffer.unsafe_ptr(),
-                xts_rounds,
-                grid_dim=grid_dim,
-                block_dim=block_dim,
-            )
-            round_keys1.free()
-            round_keys2.free()
-            key1_ptr.free()
-            key2_ptr.free()
         else:
             ctx.enqueue_function[aes_gpu_kernel_ecb](
                 input_buffer.unsafe_ptr(),
@@ -444,8 +377,7 @@ def main() raises:
         var json_data = load_json("tests/vectors/aes_test_vectors.json", py)
         var modes = ["AES-128-ECB", "AES-192-ECB", "AES-256-ECB", 
                      "AES-128-CTR", "AES-192-CTR", "AES-256-CTR",
-                     "AES-128-GCM", "AES-192-GCM", "AES-256-GCM",
-                     "AES-128-XTS", "AES-256-XTS"]
+                     "AES-128-GCM", "AES-192-GCM", "AES-256-GCM"]
         
         for mode in modes:
             print("Loading " + mode + " vectors...")

--- a/tests/test_aes_gpu.mojo
+++ b/tests/test_aes_gpu.mojo
@@ -9,8 +9,6 @@ from std.memory import alloc
 from std.gpu.host import DeviceContext
 from std.memory.unsafe_pointer import UnsafePointer
 
-# This is a test file this is only for testing purposes.
-# This file will be removed later on.
 
 def byte_to_hex(b: UInt8) -> String:
     var hi = Int(b >> 4)

--- a/tests/test_aes_gpu.mojo
+++ b/tests/test_aes_gpu.mojo
@@ -116,7 +116,7 @@ def test_aes_gpu_basic(json_data: PythonObject, py: PythonObject) raises -> Test
             var block_dim = 1
             var grid_dim = 4
             
-            ctx.enqueue_function[aes_gpu_kernel_ecb, aes_gpu_kernel_ecb](
+            ctx.enqueue_function[aes_gpu_kernel_ecb](
                 input_buffer.unsafe_ptr(),
                 output_buffer.unsafe_ptr(),
                 round_keys_buffer.unsafe_ptr(),
@@ -246,7 +246,7 @@ def test_mode_gpu(json_data: PythonObject, mode: String) raises -> TestResult:
             rounds = 14
         
         if "ECB" in mode:
-            ctx.enqueue_function[aes_gpu_kernel_ecb, aes_gpu_kernel_ecb](
+            ctx.enqueue_function[aes_gpu_kernel_ecb](
                 input_buffer.unsafe_ptr(),
                 output_buffer.unsafe_ptr(),
                 round_keys_buffer.unsafe_ptr(),
@@ -269,7 +269,7 @@ def test_mode_gpu(json_data: PythonObject, mode: String) raises -> TestResult:
             
             var nonce_buffer = ctx.enqueue_create_buffer[DType.uint8](16)
             ctx.enqueue_copy(nonce_buffer, nonce_ptr)
-            ctx.enqueue_function[aes_gpu_kernel_ctr, aes_gpu_kernel_ctr](
+            ctx.enqueue_function[aes_gpu_kernel_ctr](
                 input_buffer.unsafe_ptr(),
                 output_buffer.unsafe_ptr(),
                 round_keys_buffer.unsafe_ptr(),
@@ -293,7 +293,7 @@ def test_mode_gpu(json_data: PythonObject, mode: String) raises -> TestResult:
             
             var nonce_buffer = ctx.enqueue_create_buffer[DType.uint8](12)
             ctx.enqueue_copy(nonce_buffer, nonce_ptr)
-            ctx.enqueue_function[aes_gpu_kernel_gcm, aes_gpu_kernel_gcm](
+            ctx.enqueue_function[aes_gpu_kernel_gcm](
                 input_buffer.unsafe_ptr(),
                 output_buffer.unsafe_ptr(),
                 round_keys_buffer.unsafe_ptr(),
@@ -348,7 +348,7 @@ def test_mode_gpu(json_data: PythonObject, mode: String) raises -> TestResult:
             ctx.enqueue_copy(tweak_buffer, tweak_ptr)
             ctx.synchronize()
             
-            ctx.enqueue_function[aes_gpu_kernel_xts, aes_gpu_kernel_xts](
+            ctx.enqueue_function[aes_gpu_kernel_xts](
                 input_buffer.unsafe_ptr(),
                 output_buffer.unsafe_ptr(),
                 round_keys1_buffer.unsafe_ptr(),
@@ -365,7 +365,7 @@ def test_mode_gpu(json_data: PythonObject, mode: String) raises -> TestResult:
             key1_ptr.free()
             key2_ptr.free()
         else:
-            ctx.enqueue_function[aes_gpu_kernel_ecb, aes_gpu_kernel_ecb](
+            ctx.enqueue_function[aes_gpu_kernel_ecb](
                 input_buffer.unsafe_ptr(),
                 output_buffer.unsafe_ptr(),
                 round_keys_buffer.unsafe_ptr(),

--- a/tests/test_aes_gpu.mojo
+++ b/tests/test_aes_gpu.mojo
@@ -238,6 +238,7 @@ def test_mode_gpu(json_data: PythonObject, mode: String) raises -> TestResult:
         else:
             rounds = 14
         
+        var nonce_ptr = alloc[UInt8](16)
         if "ECB" in mode:
             ctx.enqueue_function[aes_gpu_kernel_ecb](
                 input_buffer.unsafe_ptr(),
@@ -251,7 +252,6 @@ def test_mode_gpu(json_data: PythonObject, mode: String) raises -> TestResult:
             )
         elif "CTR" in mode:
             var iv_hex = String(tv.get("iv", PythonObject()))
-            var nonce_ptr = alloc[UInt8](16)
             if iv_hex.byte_length() == 0:
                 for j in range(16):
                     nonce_ptr[j] = 0
@@ -275,7 +275,6 @@ def test_mode_gpu(json_data: PythonObject, mode: String) raises -> TestResult:
             )
         elif "GCM" in mode:
             var nonce_hex = String(tv.get("nonce", PythonObject()))
-            var nonce_ptr = alloc[UInt8](12)
             if nonce_hex.byte_length() == 0:
                 for j in range(12):
                     nonce_ptr[j] = 0
@@ -338,6 +337,7 @@ def test_mode_gpu(json_data: PythonObject, mode: String) raises -> TestResult:
         round_keys.free()
         pt_ptr.free()
         ct_ptr.free()
+        nonce_ptr.free()
     
     return TestResult(passed, failed, failures^)
 

--- a/tests/test_wycheproof_ed25519.mojo
+++ b/tests/test_wycheproof_ed25519.mojo
@@ -1,9 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
-
 """
 Wycheproof Ed25519 test suite
-By Libalpm64, no attribution required.
 """
 
 from std.collections import List

--- a/tests/test_wycheproof_p256_ecdh.mojo
+++ b/tests/test_wycheproof_p256_ecdh.mojo
@@ -1,6 +1,5 @@
 """
 This test file is for testing the Wycheproof P-256 ECDH test vectors.
-By Libalpm64, no attribution required.
 """
 from std.collections import List
 from std.python import Python

--- a/tests/test_wycheproof_p256_ecdh.mojo
+++ b/tests/test_wycheproof_p256_ecdh.mojo
@@ -1,12 +1,12 @@
+"""
+This test file is for testing the Wycheproof P-256 ECDH test vectors.
+By Libalpm64, no attribution required.
+"""
 from std.collections import List
 from std.python import Python
 from thistle.p256 import p256_ecdh
 from thistle.utils import StackInlineArray
 
-"""
-This test file is for testing the Wycheproof P-256 ECDH test vectors.
-By Libalpm64, no attribution required.
-"""
 
 def hex_to_bytes(s: String) -> List[UInt8]:
     var r = List[UInt8]()

--- a/tests/test_wycheproof_p384_ecdh.mojo
+++ b/tests/test_wycheproof_p384_ecdh.mojo
@@ -1,6 +1,5 @@
 """
 This test file is for testing the Wycheproof P-384 ECDH test vectors.
-By Libalpm64, no attribution required.
 """
 from std.collections import List
 from std.python import Python

--- a/tests/test_wycheproof_p384_ecdh.mojo
+++ b/tests/test_wycheproof_p384_ecdh.mojo
@@ -1,12 +1,12 @@
+"""
+This test file is for testing the Wycheproof P-384 ECDH test vectors.
+By Libalpm64, no attribution required.
+"""
 from std.collections import List
 from std.python import Python
 from thistle.p384 import p384_ecdh
 from thistle.utils import StackInlineArray
 
-"""
-This test file is for testing the Wycheproof P-384 ECDH test vectors.
-By Libalpm64, no attribution required.
-"""
 
 def hex_to_bytes(s: String) -> List[UInt8]:
     var r = List[UInt8]()

--- a/tests/test_wycheproof_x25519.mojo
+++ b/tests/test_wycheproof_x25519.mojo
@@ -1,8 +1,5 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2026 Libalpm64, Lostlab Technologies.
 """
 Wycheproof X25519 test suite
-By Libalpm64
 """
 from std.collections import List
 from std.python import Python

--- a/tests/test_wycheproof_x25519.mojo
+++ b/tests/test_wycheproof_x25519.mojo
@@ -27,7 +27,7 @@ def matches32(actual: StackInlineArray[UInt8, 32], expected: List[UInt8]) -> Boo
             return False
     return True
 
-def run_case(tc_id: String, private_hex: String, public_hex: String, shared_hex: String) -> Bool:
+def run_case(tc_id: String, private_hex: String, public_hex: String, shared_hex: String) raises -> Bool:
     var private_key = hex_to_bytes(private_hex)
     var public_key = hex_to_bytes(public_hex)
     var expected = hex_to_bytes(shared_hex)


### PR DESCRIPTION
- make most functions brancless
- added input checks / zeroization
- make carry reduce ~2.5x
- bit by bit reduce ~10x field mut in 0-256
- Added ARMv8 SHA2 support
- Added ciphertext buffer check size check (was OOB write)
- Counter wrap guard for nonce (was silent keystream reuse)
- out_length/key bounds validation (was OOB past state)
- StackInlineArray is now pointer based InlineArray backed value type
- Removed XTS on GPU (was very slow)
- Removed annoying headers
- Added a missing RFC upper-bound checks before serialization/allocation in Argon2.
- Route the remaining BLAKE3 lane updates through g_idx-style copies directly into g_vertical.
- Added Limit private-key hashing to the seed bytes you validated.
- Gated SHA-NI dispatch on feature checks