### PR TITLE
Fix CTR counter wrap, unaligned SIMD loads, and key issues

### DIFF
--- a/src/thistle/aes.mojo
+++ b/src/thistle/aes.mojo
@@ -2,7 +2,7 @@
 AES CPU implementation
 """
 
-from std.memory import alloc
+from std.memory import alloc, memset_zero
 from std.utils import StaticTuple
 from .utils import StackBuffer
 
@@ -330,17 +330,13 @@ def cpu_aes_ctr_kernel(
         for j in range(16):
             tp.store(j, nonce_ptr[j])
 
-        var ctr = (
-            (UInt32(nonce_ptr[12]) << 24)
-            | (UInt32(nonce_ptr[13]) << 16)
-            | (UInt32(nonce_ptr[14]) << 8)
-            | UInt32(nonce_ptr[15])
-        ) + UInt32(i)
-
-        tp.store(12, UInt8((ctr >> 24) & 0xff))
-        tp.store(13, UInt8((ctr >> 16) & 0xff))
-        tp.store(14, UInt8((ctr >> 8) & 0xff))
-        tp.store(15, UInt8(ctr & 0xff))
+        var carry = UInt64(i)
+        for j in range(15, -1, -1):
+            if carry == 0:
+                break
+            var total = UInt64(tp.load(j)) + (carry & 0xFF)
+            tp.store(j, UInt8(total & 0xFF))
+            carry = (carry >> 8) + (total >> 8)
 
         if rounds == 10:
             _cpu_aes_encrypt[10](tp, round_keys)
@@ -537,7 +533,8 @@ struct AESKey:
         expand_key_128_into(self._data.ptr(), self._round_keys.ptr())
     
     def __del__(deinit self):
-        pass
-    
+        memset_zero(self._data.ptr(), 16)
+        memset_zero(self._round_keys.ptr(), 44)
+
     def round_keys(mut self) -> UnsafePointer[UInt32, MutAnyOrigin]:
         return self._round_keys.ptr()

--- a/src/thistle/blake2b.mojo
+++ b/src/thistle/blake2b.mojo
@@ -88,10 +88,14 @@ struct Blake2b(Movable):
     var h: SIMD[DType.uint64, 8]
     var t_low: UInt64
     var t_high: UInt64
-    var buffer: UnsafePointer[UInt8, MutAnyOrigin]
+    var buffer: InlineArray[UInt64, 16]
     var buffer_len: Int
     var out_len: Int
     var key_len: Int
+
+    @always_inline
+    def _buf_ptr(mut self) -> UnsafePointer[UInt8, MutAnyOrigin]:
+        return self.buffer.unsafe_ptr().bitcast[UInt8]().unsafe_origin_cast[MutAnyOrigin]()
 
     def __init__(out self, out_len: Int = 64):
         debug_assert(1 <= out_len <= 64, "BLAKE2b digest length must be 1..64")
@@ -100,9 +104,7 @@ struct Blake2b(Movable):
         self.h = BLAKE2B_IV
         self.t_low = 0
         self.t_high = 0
-        self.buffer = alloc[UInt8](128)
-        for i in range(128):
-            self.buffer[i] = 0
+        self.buffer = InlineArray[UInt64, 16](fill=0)
         self.buffer_len = 0
 
         var p0: UInt64 = 0x01010000
@@ -119,9 +121,7 @@ struct Blake2b(Movable):
         self.h = BLAKE2B_IV
         self.t_low = 0
         self.t_high = 0
-        self.buffer = alloc[UInt8](128)
-        for i in range(128):
-            self.buffer[i] = 0
+        self.buffer = InlineArray[UInt64, 16](fill=0)
         self.buffer_len = 0
 
         var p0: UInt64 = 0x01010000
@@ -132,21 +132,22 @@ struct Blake2b(Movable):
 
         if self.key_len > 0:
             self.update(key)
+            var buf = self._buf_ptr()
             while self.buffer_len < 128:
-                self.buffer[self.buffer_len] = 0
+                buf[self.buffer_len] = 0
                 self.buffer_len += 1
 
     def __init__(out self, *, deinit take: Self):
         self.h = take.h
         self.t_low = take.t_low
         self.t_high = take.t_high
-        self.buffer = take.buffer
+        self.buffer = take.buffer^
         self.buffer_len = take.buffer_len
         self.out_len = take.out_len
         self.key_len = take.key_len
 
     def __del__(deinit self):
-        zero_and_free(self.buffer, 128)
+        memset_zero(self.buffer.unsafe_ptr(), 16)
 
     def compress(mut self, is_last: Bool):
         var v0 = self.h[0]
@@ -172,7 +173,7 @@ struct Blake2b(Movable):
         if is_last:
             v14 ^= 0xFFFFFFFFFFFFFFFF
 
-        var m = self.buffer.bitcast[UInt64]()
+        var m = self.buffer.unsafe_ptr().unsafe_origin_cast[MutAnyOrigin]()
         
         (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) = round_fn[0](v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, m)
         (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) = round_fn[1](v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, m)
@@ -213,7 +214,7 @@ struct Blake2b(Movable):
                 to_copy = remaining_data
 
             memcpy(
-                dest=self.buffer + self.buffer_len,
+                dest=self._buf_ptr() + self.buffer_len,
                 src=data.unsafe_ptr() + i,
                 count=to_copy,
             )
@@ -227,8 +228,9 @@ struct Blake2b(Movable):
         if self.t_low < old_low:
             self.t_high += 1
 
+        var buf = self._buf_ptr()
         while self.buffer_len < 128:
-            self.buffer[self.buffer_len] = 0
+            buf[self.buffer_len] = 0
             self.buffer_len += 1
 
         self.compress(True)
@@ -255,7 +257,7 @@ def nibble_to_hex_char(nibble: UInt8) -> UInt8:
 
 
 def bytes_to_hex(data: List[UInt8]) -> String:
-    var result = String()
+    var result = String(capacity=len(data) * 2)
     for i in range(len(data)):
         var b = data[i]
         var high = (b >> 4) & 0x0F

--- a/src/thistle/blake3.mojo
+++ b/src/thistle/blake3.mojo
@@ -432,7 +432,7 @@ struct Hasher:
         while len(d) > 0:
             if self.buf_len == 64:
                 var blk = (
-                    self.buf.unsafe_ptr().bitcast[UInt32]().load[width=16]()
+                    self.buf.unsafe_ptr().bitcast[UInt32]().load[width=16, alignment=1]()
                 )
 
                 if self.blocks_compressed == 15:
@@ -520,7 +520,7 @@ struct Hasher:
         for i in range(self.buf_len):
             temp_buf.unsafe_set(i, self.buf[i])
 
-        var blk = temp_buf.unsafe_ptr().bitcast[UInt32]().load[width=16]()
+        var blk = temp_buf.unsafe_ptr().bitcast[UInt32]().load[width=16, alignment=1]()
 
         var flags = (
             CHUNK_START if self.blocks_compressed == 0 else UInt8(0)
@@ -626,7 +626,7 @@ def blake3_parallel_hash(input: Span[UInt8, ...], out_len: Int = 32) -> List[UIn
                     @parameter
                     @always_inline
                     def _load_idx(v: Int) -> SIMD[DType.uint32, 4]:
-                        return base_ptr.load[width=4](
+                        return base_ptr.load[width=4, alignment=1](
                             (base + v) * 256 + b * 16 + joff
                         )
 

--- a/src/thistle/chacha20.mojo
+++ b/src/thistle/chacha20.mojo
@@ -335,7 +335,7 @@ struct ChaCha20:
     def _check_counter_space(self, data_len: Int) raises:
         var blocks_needed = UInt64((data_len + 63) // 64)
         var space = UInt64(0x100000000) - UInt64(self.counter)
-        if blocks_needed > space:
+        if blocks_needed >= space:
             raise Error("ChaCha20 counter would wrap; use a new nonce")
 
     def encrypt_into[origin: Origin[mut=True]](

--- a/src/thistle/random.mojo
+++ b/src/thistle/random.mojo
@@ -121,8 +121,6 @@ def random_fill(buf: UnsafePointer[UInt8, MutAnyOrigin], length: Int) raises:
 def random_bytes(n: Int) raises -> List[UInt8]:
     if n < 0:
         raise Error("random_bytes length must be non-negative")
-    var result = List[UInt8](capacity=n)
-    for _ in range(n):
-        result.append(0)
+    var result = List[UInt8](length=n, fill=0)
     random_fill(result.unsafe_ptr(), n)
     return result^

--- a/src/thistle/sha_ni.mojo
+++ b/src/thistle/sha_ni.mojo
@@ -112,7 +112,7 @@ def byte_swap32(v: SIMD128) -> SIMD128:
 
 @always_inline("nodebug")
 def Load(ptr: UnsafePointer[UInt8, ImmutAnyOrigin]) -> SIMD128:
-    return byte_swap32(ptr.bitcast[UInt32]().load[width=4]())
+    return byte_swap32(ptr.bitcast[UInt32]().load[width=4, alignment=1]())
 
 
 @always_inline("nodebug")


### PR DESCRIPTION
- Carry CTR block index through the full 16-byte big-endian counter instead of wrapping at 2^32 so keystream doesn't get reused inside a message
- Zero out AES key material and expanded round keys on destruction
- Reject ChaCha20 calls when the counter exactly fills the available space to prevent wrapping to 0 on later calls
- Use alignment 1 for wide loads in Blake3 and SHA-NI since byte buffers and caller input don't guarantee alignment
- Replace Blake2b's heap-allocated 128-byte block buffer with an aligned inline UInt64 array and reserve capacity in bytes_to_hex
- Write directly into the random_bytes result buffer instead of appending byte by byte

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cryptographic safety and boundary checks to better prevent counter wraparound and other edge-case failures.
  * Fixed several low-level data handling paths to work more reliably with unaligned memory.
  * Strengthened sensitive data cleanup so keys and internal buffers are cleared more consistently.
  * Improved random byte generation efficiency and reduced unnecessary allocation overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->